### PR TITLE
Add CI workflow and document dependency install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build

--- a/README.md
+++ b/README.md
@@ -14,12 +14,23 @@ Install dependencies:
 npm install
 ```
 
+Run the above command before executing `npm run dev`, `npm run build`,
+or `npm run lint`. These scripts require all dependencies to be installed.
+
 ## Development
 
 Start a development server with hot reload:
 
 ```bash
 npm run dev
+```
+
+## Linting
+
+Check code quality using ESLint:
+
+```bash
+npm run lint
 ```
 
 ## Production


### PR DESCRIPTION
## Summary
- document that `npm install` is required before running `dev`, `build`, or `lint`
- mention linting instructions
- add a GitHub Actions workflow to install dependencies, lint, and build

## Testing
- `npm run lint` *(fails: `next` not found because dependencies could not be installed)*
- `npm run build` *(fails: missing dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_687be8718e748330910b36f19bf50f3b