### PR TITLE
Update font paths

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -16,14 +16,14 @@ class MyDocument extends Document<{ locale: string }> {
           {/* Preload font (ตัวอย่าง) */}
           <link
             rel="preload"
-            href="/fonts/Prompt-Regular.ttf"
+            href="/fonts/Prompt/Prompt-Regular.ttf"
             as="font"
             type="font/ttf"
             crossOrigin="anonymous"
           />
           <link
             rel="preload"
-            href="/fonts/Inter-Regular.ttf"
+            href="/fonts/Inter/Inter-Regular.ttf"
             as="font"
             type="font/ttf"
             crossOrigin="anonymous"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,14 +5,14 @@
 /* ================== INTER ================== */
 @font-face {
   font-family: 'Inter';
-  src: url('/fonts/Inter_18pt-Thin.ttf') format('truetype');
+  src: url('/fonts/Inter/Inter_18pt-Thin.ttf') format('truetype');
   font-weight: 100;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'Inter';
-  src: url('/fonts/Inter_18pt-ThinItalic.ttf') format('truetype');
+  src: url('/fonts/Inter/Inter_18pt-ThinItalic.ttf') format('truetype');
   font-weight: 100;
   font-style: italic;
   font-display: swap;
@@ -20,14 +20,14 @@
 
 @font-face {
   font-family: 'Inter';
-  src: url('/fonts/Inter_18pt-ExtraLight.ttf') format('truetype');
+  src: url('/fonts/Inter/Inter_18pt-ExtraLight.ttf') format('truetype');
   font-weight: 200;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'Inter';
-  src: url('/fonts/Inter_18pt-ExtraLightItalic.ttf') format('truetype');
+  src: url('/fonts/Inter/Inter_18pt-ExtraLightItalic.ttf') format('truetype');
   font-weight: 200;
   font-style: italic;
   font-display: swap;
@@ -35,14 +35,14 @@
 
 @font-face {
   font-family: 'Inter';
-  src: url('/fonts/Inter_18pt-Light.ttf') format('truetype');
+  src: url('/fonts/Inter/Inter_18pt-Light.ttf') format('truetype');
   font-weight: 300;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'Inter';
-  src: url('/fonts/Inter_18pt-LightItalic.ttf') format('truetype');
+  src: url('/fonts/Inter/Inter_18pt-LightItalic.ttf') format('truetype');
   font-weight: 300;
   font-style: italic;
   font-display: swap;
@@ -50,14 +50,14 @@
 
 @font-face {
   font-family: 'Inter';
-  src: url('/fonts/Inter_18pt-Regular.ttf') format('truetype');
+  src: url('/fonts/Inter/Inter_18pt-Regular.ttf') format('truetype');
   font-weight: 400;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'Inter';
-  src: url('/fonts/Inter_18pt-Italic.ttf') format('truetype');
+  src: url('/fonts/Inter/Inter_18pt-Italic.ttf') format('truetype');
   font-weight: 400;
   font-style: italic;
   font-display: swap;
@@ -65,14 +65,14 @@
 
 @font-face {
   font-family: 'Inter';
-  src: url('/fonts/Inter_18pt-Medium.ttf') format('truetype');
+  src: url('/fonts/Inter/Inter_18pt-Medium.ttf') format('truetype');
   font-weight: 500;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'Inter';
-  src: url('/fonts/Inter_18pt-MediumItalic.ttf') format('truetype');
+  src: url('/fonts/Inter/Inter_18pt-MediumItalic.ttf') format('truetype');
   font-weight: 500;
   font-style: italic;
   font-display: swap;
@@ -80,14 +80,14 @@
 
 @font-face {
   font-family: 'Inter';
-  src: url('/fonts/Inter_18pt-SemiBold.ttf') format('truetype');
+  src: url('/fonts/Inter/Inter_18pt-SemiBold.ttf') format('truetype');
   font-weight: 600;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'Inter';
-  src: url('/fonts/Inter_18pt-SemiBoldItalic.ttf') format('truetype');
+  src: url('/fonts/Inter/Inter_18pt-SemiBoldItalic.ttf') format('truetype');
   font-weight: 600;
   font-style: italic;
   font-display: swap;
@@ -95,14 +95,14 @@
 
 @font-face {
   font-family: 'Inter';
-  src: url('/fonts/Inter_18pt-Bold.ttf') format('truetype');
+  src: url('/fonts/Inter/Inter_18pt-Bold.ttf') format('truetype');
   font-weight: 700;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'Inter';
-  src: url('/fonts/Inter_18pt-BoldItalic.ttf') format('truetype');
+  src: url('/fonts/Inter/Inter_18pt-BoldItalic.ttf') format('truetype');
   font-weight: 700;
   font-style: italic;
   font-display: swap;
@@ -110,14 +110,14 @@
 
 @font-face {
   font-family: 'Inter';
-  src: url('/fonts/Inter_18pt-ExtraBold.ttf') format('truetype');
+  src: url('/fonts/Inter/Inter_18pt-ExtraBold.ttf') format('truetype');
   font-weight: 800;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'Inter';
-  src: url('/fonts/Inter_18pt-ExtraBoldItalic.ttf') format('truetype');
+  src: url('/fonts/Inter/Inter_18pt-ExtraBoldItalic.ttf') format('truetype');
   font-weight: 800;
   font-style: italic;
   font-display: swap;
@@ -125,14 +125,14 @@
 
 @font-face {
   font-family: 'Inter';
-  src: url('/fonts/Inter_18pt-Black.ttf') format('truetype');
+  src: url('/fonts/Inter/Inter_18pt-Black.ttf') format('truetype');
   font-weight: 900;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'Inter';
-  src: url('/fonts/Inter_18pt-BlackItalic.ttf') format('truetype');
+  src: url('/fonts/Inter/Inter_18pt-BlackItalic.ttf') format('truetype');
   font-weight: 900;
   font-style: italic;
   font-display: swap;
@@ -141,126 +141,126 @@
 /* ================== PROMPT ================== */
 @font-face {
   font-family: 'Prompt';
-  src: url('/fonts/Prompt-Thin.ttf') format('truetype');
+  src: url('/fonts/Prompt/Prompt-Thin.ttf') format('truetype');
   font-weight: 100;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'Prompt';
-  src: url('/fonts/Prompt-ThinItalic.ttf') format('truetype');
+  src: url('/fonts/Prompt/Prompt-ThinItalic.ttf') format('truetype');
   font-weight: 100;
   font-style: italic;
   font-display: swap;
 }
 @font-face {
   font-family: 'Prompt';
-  src: url('/fonts/Prompt-ExtraLight.ttf') format('truetype');
+  src: url('/fonts/Prompt/Prompt-ExtraLight.ttf') format('truetype');
   font-weight: 200;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'Prompt';
-  src: url('/fonts/Prompt-ExtraLightItalic.ttf') format('truetype');
+  src: url('/fonts/Prompt/Prompt-ExtraLightItalic.ttf') format('truetype');
   font-weight: 200;
   font-style: italic;
   font-display: swap;
 }
 @font-face {
   font-family: 'Prompt';
-  src: url('/fonts/Prompt-Light.ttf') format('truetype');
+  src: url('/fonts/Prompt/Prompt-Light.ttf') format('truetype');
   font-weight: 300;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'Prompt';
-  src: url('/fonts/Prompt-LightItalic.ttf') format('truetype');
+  src: url('/fonts/Prompt/Prompt-LightItalic.ttf') format('truetype');
   font-weight: 300;
   font-style: italic;
   font-display: swap;
 }
 @font-face {
   font-family: 'Prompt';
-  src: url('/fonts/Prompt-Regular.ttf') format('truetype');
+  src: url('/fonts/Prompt/Prompt-Regular.ttf') format('truetype');
   font-weight: 400;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'Prompt';
-  src: url('/fonts/Prompt-Italic.ttf') format('truetype');
+  src: url('/fonts/Prompt/Prompt-Italic.ttf') format('truetype');
   font-weight: 400;
   font-style: italic;
   font-display: swap;
 }
 @font-face {
   font-family: 'Prompt';
-  src: url('/fonts/Prompt-Medium.ttf') format('truetype');
+  src: url('/fonts/Prompt/Prompt-Medium.ttf') format('truetype');
   font-weight: 500;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'Prompt';
-  src: url('/fonts/Prompt-MediumItalic.ttf') format('truetype');
+  src: url('/fonts/Prompt/Prompt-MediumItalic.ttf') format('truetype');
   font-weight: 500;
   font-style: italic;
   font-display: swap;
 }
 @font-face {
   font-family: 'Prompt';
-  src: url('/fonts/Prompt-SemiBold.ttf') format('truetype');
+  src: url('/fonts/Prompt/Prompt-SemiBold.ttf') format('truetype');
   font-weight: 600;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'Prompt';
-  src: url('/fonts/Prompt-SemiBoldItalic.ttf') format('truetype');
+  src: url('/fonts/Prompt/Prompt-SemiBoldItalic.ttf') format('truetype');
   font-weight: 600;
   font-style: italic;
   font-display: swap;
 }
 @font-face {
   font-family: 'Prompt';
-  src: url('/fonts/Prompt-Bold.ttf') format('truetype');
+  src: url('/fonts/Prompt/Prompt-Bold.ttf') format('truetype');
   font-weight: 700;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'Prompt';
-  src: url('/fonts/Prompt-BoldItalic.ttf') format('truetype');
+  src: url('/fonts/Prompt/Prompt-BoldItalic.ttf') format('truetype');
   font-weight: 700;
   font-style: italic;
   font-display: swap;
 }
 @font-face {
   font-family: 'Prompt';
-  src: url('/fonts/Prompt-ExtraBold.ttf') format('truetype');
+  src: url('/fonts/Prompt/Prompt-ExtraBold.ttf') format('truetype');
   font-weight: 800;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'Prompt';
-  src: url('/fonts/Prompt-ExtraBoldItalic.ttf') format('truetype');
+  src: url('/fonts/Prompt/Prompt-ExtraBoldItalic.ttf') format('truetype');
   font-weight: 800;
   font-style: italic;
   font-display: swap;
 }
 @font-face {
   font-family: 'Prompt';
-  src: url('/fonts/Prompt-Black.ttf') format('truetype');
+  src: url('/fonts/Prompt/Prompt-Black.ttf') format('truetype');
   font-weight: 900;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'Prompt';
-  src: url('/fonts/Prompt-BlackItalic.ttf') format('truetype');
+  src: url('/fonts/Prompt/Prompt-BlackItalic.ttf') format('truetype');
   font-weight: 900;
   font-style: italic;
   font-display: swap;


### PR DESCRIPTION
## Summary
- fix `@font-face` paths for Prompt and Inter fonts
- adjust preload link paths in `_document`

## Testing
- `npm run build` *(fails: ENOENT rename th.html)*

------
https://chatgpt.com/codex/tasks/task_e_687beeffad9c8330b79c38555468f8f1