### PR TITLE
Fix locale prop typing in Document

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,15 +1,29 @@
-import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document';
+import Document, {
+  Html,
+  Head,
+  Main,
+  NextScript,
+  DocumentContext,
+  DocumentProps,
+} from 'next/document';
 
-class MyDocument extends Document<{ locale: string }> {
+interface MyDocumentProps extends DocumentProps {
+  locale?: string;
+}
+class MyDocument extends Document<MyDocumentProps> {
   static async getInitialProps(ctx: DocumentContext) {
-    const initialProps = await Document.getInitialProps(ctx);
-    // locale จาก context
-    return { ...initialProps, locale: ctx.locale || 'th' };
+    const initialProps = (await Document.getInitialProps(
+      ctx
+    )) as DocumentProps;
+    return {
+      ...initialProps,
+      locale: ctx.locale || initialProps.__NEXT_DATA__.locale || 'th',
+    };
   }
 
   render() {
-    // @ts-ignore
-    const { locale } = this.props;
+    const locale =
+      this.props.locale ?? this.props.__NEXT_DATA__.locale ?? 'th';
     return (
       <Html lang={locale}>
         <Head>


### PR DESCRIPTION
## Summary
- extend Document using `DocumentProps`
- type the `locale` prop and remove ts-ignore
- safely read locale from props or `__NEXT_DATA__`

## Testing
- `npm run lint` *(fails: prompts for interactive setup)*
- `npm run build` *(fails: ENOENT: rename .next/export/th.html)*

------
https://chatgpt.com/codex/tasks/task_e_687bf19f81208330b7b6444016664fc3