### PR TITLE
Add font rules for language-specific rendering

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -22,10 +22,11 @@ class MyDocument extends Document<MyDocumentProps> {
   }
 
   render() {
-    const locale =
-      this.props.locale ?? this.props.__NEXT_DATA__.locale ?? 'th';
+    // Determine the language for the <Html> tag so our CSS selectors
+    // (e.g. html[lang="en"]) can apply the correct font family.
+    const lang = this.props.locale ?? this.props.__NEXT_DATA__.locale ?? 'th';
     return (
-      <Html lang={locale}>
+      <Html lang={lang}>
         <Head>
           {/* Preload font (ตัวอย่าง) */}
           <link

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -267,6 +267,14 @@
 }
 
 /* Global font logic */
-html, body {
-  font-family: 'Prompt', 'Inter', sans-serif;
+html {
+  font-family: sans-serif;
+}
+
+html[lang='en'] {
+  font-family: 'Inter', sans-serif;
+}
+
+html[lang='th'] {
+  font-family: 'Prompt', sans-serif;
 }


### PR DESCRIPTION
## Summary
- load fonts based on the `lang` attribute
- ensure `_document.tsx` supplies the `lang` for the `<Html>` tag

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687bf3436a4883309c96886402dc29e7