### PR TITLE
Use NextSeo for localized SEO

### DIFF
--- a/next-seo.config.js
+++ b/next-seo.config.js
@@ -1,7 +1,9 @@
 // next-seo.config.js
+// Default SEO configuration shared across all pages.
+// Individual pages should extend these options via the `NextSeo` component.
 const config = {
-  title: "Virintira | Accounting & Business",
-  description: "Multilingual accounting partner.",
+  defaultTitle: 'Virintira | Accounting & Business',
+  description: 'Multilingual accounting partner.',
   openGraph: {
     type: 'website',
     locale: 'th_TH',

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,15 +1,19 @@
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import Head from "next/head";
+import { NextSeo } from "next-seo";
+import { useRouter } from "next/router";
 import { GetStaticProps } from "next";
 
 export default function Custom404() {
   const { t } = useTranslation("common");
+  const { locale } = useRouter();
+  const ogLocale = locale === "en" ? "en_US" : "th_TH";
   return (
     <>
-      <Head>
-        <title>404 - {t("seo_title")}</title>
-      </Head>
+      <NextSeo
+        title={`404 - ${t("seo_title")}`}
+        openGraph={{ locale: ogLocale }}
+      />
       <div style={{ textAlign: "center", marginTop: "2rem" }}>
         <h1>404</h1>
         <p>{t("notFound")}</p>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,15 @@
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
 import { appWithTranslation } from 'next-i18next';
+import { DefaultSeo } from 'next-seo';
+import SEO from '../next-seo.config';
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <DefaultSeo {...SEO} />
+      <Component {...pageProps} />
+    </>
+  );
 }
 export default appWithTranslation(MyApp);

--- a/pages/en/index.tsx
+++ b/pages/en/index.tsx
@@ -1,17 +1,21 @@
-import Head from "next/head";
 import { useTranslation } from "next-i18next";
+import { NextSeo } from "next-seo";
+import { useRouter } from "next/router";
 import { LanguageSwitcher } from "../../components/LanguageSwitcher";
 import { GetStaticProps } from "next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 export default function Home() {
   const { t } = useTranslation("common");
+  const { locale } = useRouter();
+  const ogLocale = locale === "en" ? "en_US" : "th_TH";
   return (
     <>
-      <Head>
-        <title>{t("seo_title")}</title>
-        <meta name="description" content={t("seo_description")} />
-      </Head>
+      <NextSeo
+        title={t("seo_title")}
+        description={t("seo_description")}
+        openGraph={{ locale: ogLocale }}
+      />
       <main>
         <LanguageSwitcher />
         <h1>{t("welcome")}</h1>

--- a/pages/th/index.tsx
+++ b/pages/th/index.tsx
@@ -1,17 +1,21 @@
-import Head from "next/head";
 import { useTranslation } from "next-i18next";
+import { NextSeo } from "next-seo";
+import { useRouter } from "next/router";
 import { LanguageSwitcher } from "../../components/LanguageSwitcher";
 import { GetStaticProps } from "next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 export default function Home() {
   const { t } = useTranslation("common");
+  const { locale } = useRouter();
+  const ogLocale = locale === "en" ? "en_US" : "th_TH";
   return (
     <>
-      <Head>
-        <title>{t("seo_title")}</title>
-        <meta name="description" content={t("seo_description")} />
-      </Head>
+      <NextSeo
+        title={t("seo_title")}
+        description={t("seo_description")}
+        openGraph={{ locale: ogLocale }}
+      />
       <main>
         <LanguageSwitcher />
         <h1>{t("welcome")}</h1>


### PR DESCRIPTION
## Summary
- set up DefaultSeo in `_app`
- refactor pages to use `NextSeo`
- add a default configuration in `next-seo.config.js`

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run build` *(fails: ENOENT rename error)*

------
https://chatgpt.com/codex/tasks/task_e_687bf4fbf28883308f6310d1e9daab3f