### PR TITLE
Add sitemap generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ npm run build
 npm start
 ```
 
+## Sitemap
+
+After each build, the [`postbuild`](package.json) script runs
+[`next-sitemap`](https://github.com/iamvishnusankar/next-sitemap) to
+generate `sitemap.xml` and `robots.txt` under the `public/` directory.
+You can also run this step manually:
+
+```bash
+npm run postbuild
+```
+
 
 ## License
 

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+  siteUrl: 'https://your-domain.com',
+  generateRobotsTxt: true,
+  i18n: {
+    defaultLocale: 'th',
+    locales: ['th', 'en'],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postbuild": "next-sitemap"
   },
   "dependencies": {
   "next": "14.2.30",


### PR DESCRIPTION
## Summary
- configure next-sitemap with site URL and i18n settings
- generate sitemaps automatically using a `postbuild` script
- document sitemap generation in README

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_687c8de732d083309dce0198281d4954