### PR TITLE
Simplify language detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ You can also run this step manually:
 npm run postbuild
 ```
 
+## Locale detection
+
+Language detection is handled by [`middleware.ts`](middleware.ts). The middleware
+reads the `Accept-Language` header and redirects visitors to the corresponding
+`/[lang]` route. Unsupported languages fall back to the default locale (`th`).
+
 
 ## License
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -17,7 +17,8 @@ export function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
-  // detect preferred language
+  // Detect the preferred language from the request headers. If the client
+  // sends an unsupported language, fall back to the default locale.
   const acceptLang = req.headers.get("accept-language") || "";
   const preferred = acceptLang.split(",")[0].split("-")[0];
   const redirectLocale = locales.includes(preferred) ? preferred : defaultLocale;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,16 +1,5 @@
-import { useEffect } from 'react';
-import { useRouter } from 'next/router';
-
+// The middleware handles language detection and redirects to `/[lang]`.
+// This component therefore renders nothing.
 export default function Index() {
-  const router = useRouter();
-  useEffect(() => {
-    // ลอง detect ภาษาเบราว์เซอร์
-    const browserLang = (typeof window !== 'undefined' ? navigator.language.split('-')[0] : 'th');
-    if (browserLang === 'en') {
-      router.replace('/en');
-    } else {
-      router.replace('/th');
-    }
-  }, [router]);
   return null;
 }


### PR DESCRIPTION
## Summary
- rely on middleware for locale detection
- remove browser language check from root index page
- clarify in README where detection happens

## Testing
- `npx next build`

------
https://chatgpt.com/codex/tasks/task_e_687ca6c4dc888330984d86f3782c0531