### PR TITLE
Fix LanguageSwitcher import

### DIFF
--- a/pages/[lang]/index.tsx
+++ b/pages/[lang]/index.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { NextSeo } from "next-seo";
 import nextI18NextConfig from "../../next-i18next.config";
-import { LanguageSwitcher } from "../../components/LanguageSwitcher";
+import LanguageSwitcher from "../../components/LanguageSwitcher";
 
 export default function Home() {
   const { t } = useTranslation("common");


### PR DESCRIPTION
## Summary
- switch to default import for `LanguageSwitcher`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ddfff32308330891b53437e911997