### PR TITLE
Always redirect / to default locale

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -19,9 +19,7 @@ export function middleware(req: NextRequest) {
 
   // Detect the preferred language from the request headers. If the client
   // sends an unsupported language, fall back to the default locale.
-  const acceptLang = req.headers.get("accept-language") || "";
-  const preferred = acceptLang.split(",")[0].split("-")[0];
-  const redirectLocale = locales.includes(preferred) ? preferred : defaultLocale;
+  const redirectLocale = defaultLocale;
 
   return NextResponse.redirect(new URL(`/${redirectLocale}${pathname}`, req.url));
 }


### PR DESCRIPTION
## Summary
- remove Accept-Language detection from middleware and always redirect to default locale

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_687de9a51ad48330a71b9c5b851b1b16