### PR TITLE
Fix middleware comment

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -17,8 +17,8 @@ export function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
-  // Detect the preferred language from the request headers. If the client
-  // sends an unsupported language, fall back to the default locale.
+  // Always redirect to the default locale.
+  // Previous versions inspected the Accept-Language header to pick a locale.
   const redirectLocale = defaultLocale;
 
   return NextResponse.redirect(new URL(`/${redirectLocale}${pathname}`, req.url));


### PR DESCRIPTION
## Summary
- clarify the comment for redirect logic in `middleware.ts`

## Testing
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_687e4b8f56dc83309ce35f75c0ee0894