### PR TITLE
Fix font path in Document

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -24,7 +24,7 @@ class MyDocument extends Document<{ locale?: string }> {
           />
           <link
             rel="preload"
-            href="/fonts/Inter/Inter-Regular.ttf"
+            href="/fonts/Inter/Inter_18pt-Regular.ttf"
             as="font"
             type="font/ttf"
             crossOrigin="anonymous"


### PR DESCRIPTION
## Summary
- correct the Inter preload font path in `_document.tsx`

## Testing
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_687fa7b707948330bc60cd4374b9f668