### PR TITLE
Use NEXT_PUBLIC_SITE_URL for absolute URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ npm install
 Run the above command before executing `npm run dev`, `npm run build`,
 or `npm run lint`. These scripts require all dependencies to be installed.
 
+## Environment variables
+
+Set `NEXT_PUBLIC_SITE_URL` to the fully qualified URL of your deployed site:
+
+```bash
+NEXT_PUBLIC_SITE_URL=https://example.com
+```
+
+This value is used when generating SEO metadata and the sitemap so that all
+links include an absolute URL.
+
 ## Development
 
 Start a development server with hot reload:

--- a/next-seo.config.js
+++ b/next-seo.config.js
@@ -7,7 +7,7 @@ const config = {
   openGraph: {
     type: 'website',
     locale: 'th_TH',
-    url: 'https://your-domain.com/',
+    url: process.env.NEXT_PUBLIC_SITE_URL || 'https://your-domain.com/',
     site_name: 'Virintira',
   },
   twitter: {

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
-  siteUrl: 'https://your-domain.com',
+  siteUrl: process.env.NEXT_PUBLIC_SITE_URL || 'https://your-domain.com',
   generateRobotsTxt: true,
   i18n: {
     defaultLocale: 'th',

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,7 +11,7 @@ export default function Home() {
   const { asPath, defaultLocale } = useRouter()
   const lang = asPath.split('/')[1] || defaultLocale || 'th'
   const ogLocale = lang === 'en' ? 'en_US' : 'th_TH'
-  const baseUrl = 'https://your-domain.com'
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://your-domain.com'
   const pageUrl = lang === defaultLocale ? baseUrl : `${baseUrl}/${lang}`
   return (
     <>


### PR DESCRIPTION
## Summary
- read `NEXT_PUBLIC_SITE_URL` in `pages/index.tsx`
- use the site URL in SEO and sitemap configs
- document the environment variable

## Testing
- `npx next lint`

------
https://chatgpt.com/codex/tasks/task_e_687fb912a83c83308ff95c9fd2d127f4