### PR TITLE
Use router locale for error page language

### DIFF
--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router'
 
 export default function LanguageSwitcher() {
   const router = useRouter()
-  const { locale, asPath, pathname, query } = router
+  const { locale, defaultLocale, asPath, pathname, query } = router
 
   // ลิสต์ภาษา
   const languages = [
@@ -15,14 +15,15 @@ export default function LanguageSwitcher() {
       {languages.map((lang) => (
         <button
           key={lang.code}
-          disabled={locale === lang.code}
+          disabled={(locale ?? defaultLocale) === lang.code}
           onClick={() => {
             // ใช้ pathname + query เพื่อไม่ให้ path หาย
             router.push({ pathname, query }, asPath, { locale: lang.code })
           }}
           style={{
             marginRight: 8,
-            fontWeight: locale === lang.code ? 'bold' : 'normal'
+            fontWeight:
+              (locale ?? defaultLocale) === lang.code ? 'bold' : 'normal'
           }}
         >
           {lang.label}

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -7,8 +7,9 @@ import nextI18NextConfig from "../next-i18next.config";
 
 export default function Custom404() {
   const { t } = useTranslation("common");
-  const { asPath } = useRouter();
-  const lang = asPath.split("/")[1] || nextI18NextConfig.i18n.defaultLocale;
+  const { locale, defaultLocale } = useRouter();
+  const lang =
+    locale ?? defaultLocale ?? nextI18NextConfig.i18n.defaultLocale;
   const ogLocale = lang === "en" ? "en_US" : "th_TH";
   return (
     <>

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -7,8 +7,9 @@ import nextI18NextConfig from "../next-i18next.config";
 
 export default function Custom500() {
   const { t } = useTranslation("common");
-  const { asPath } = useRouter();
-  const lang = asPath.split("/")[1] || nextI18NextConfig.i18n.defaultLocale;
+  const { locale, defaultLocale } = useRouter();
+  const lang =
+    locale ?? defaultLocale ?? nextI18NextConfig.i18n.defaultLocale;
   const ogLocale = lang === "en" ? "en_US" : "th_TH";
   return (
     <>


### PR DESCRIPTION
## Summary
- get current lang from `router.locale` instead of parsing `asPath`
- fall back to `router.defaultLocale` when needed

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687fbb23a790833095bf169d59dc1fc0