### PR TITLE
feat: add canonical urls

### DIFF
--- a/next-seo.config.js
+++ b/next-seo.config.js
@@ -1,13 +1,16 @@
 // next-seo.config.js
 // Default SEO configuration shared across all pages.
 // Individual pages should extend these options via the `NextSeo` component.
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://your-domain.com/';
+
 const config = {
+  baseUrl: siteUrl,
   defaultTitle: 'Virintira | Accounting & Business',
   description: 'Multilingual accounting partner.',
   openGraph: {
     type: 'website',
     locale: 'th_TH',
-    url: process.env.NEXT_PUBLIC_SITE_URL || 'https://your-domain.com/',
+    url: siteUrl,
     site_name: 'Virintira',
   },
   twitter: {

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -4,6 +4,7 @@ import { NextSeo } from "next-seo";
 import { useRouter } from "next/router";
 import { GetStaticProps } from "next";
 import nextI18NextConfig from "../next-i18next.config";
+import defaultSeo from "../next-seo.config";
 
 export default function Custom404() {
   const { t } = useTranslation("common");
@@ -11,11 +12,21 @@ export default function Custom404() {
   const lang =
     locale ?? defaultLocale ?? nextI18NextConfig.i18n.defaultLocale;
   const ogLocale = lang === "en" ? "en_US" : "th_TH";
+  const baseUrl = defaultSeo.baseUrl;
+  const pageUrl =
+    lang === defaultLocale
+      ? `${baseUrl}/404`
+      : `${baseUrl}/${lang}/404`;
   return (
     <>
       <NextSeo
         title={`404 - ${t("seo_title")}`}
-        openGraph={{ locale: ogLocale }}
+        canonical={pageUrl}
+        openGraph={{
+          ...defaultSeo.openGraph,
+          locale: ogLocale,
+          url: pageUrl,
+        }}
       />
       <div style={{ textAlign: "center", marginTop: "2rem" }}>
         <h1>404</h1>

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -4,6 +4,7 @@ import { NextSeo } from "next-seo";
 import { useRouter } from "next/router";
 import { GetStaticProps } from "next";
 import nextI18NextConfig from "../next-i18next.config";
+import defaultSeo from "../next-seo.config";
 
 export default function Custom500() {
   const { t } = useTranslation("common");
@@ -11,11 +12,21 @@ export default function Custom500() {
   const lang =
     locale ?? defaultLocale ?? nextI18NextConfig.i18n.defaultLocale;
   const ogLocale = lang === "en" ? "en_US" : "th_TH";
+  const baseUrl = defaultSeo.baseUrl;
+  const pageUrl =
+    lang === defaultLocale
+      ? `${baseUrl}/500`
+      : `${baseUrl}/${lang}/500`;
   return (
     <>
       <NextSeo
         title={`500 - ${t("seo_title")}`}
-        openGraph={{ locale: ogLocale }}
+        canonical={pageUrl}
+        openGraph={{
+          ...defaultSeo.openGraph,
+          locale: ogLocale,
+          url: pageUrl,
+        }}
       />
       <div style={{ textAlign: "center", marginTop: "2rem" }}>
         <h1>500</h1>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,13 +11,14 @@ export default function Home() {
   const { asPath, defaultLocale } = useRouter()
   const lang = asPath.split('/')[1] || defaultLocale || 'th'
   const ogLocale = lang === 'en' ? 'en_US' : 'th_TH'
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://your-domain.com'
+  const baseUrl = defaultSeo.baseUrl
   const pageUrl = lang === defaultLocale ? baseUrl : `${baseUrl}/${lang}`
   return (
     <>
       <NextSeo
         title={t('seo_title')}
         description={t('seo_description')}
+        canonical={pageUrl}
         openGraph={{
           ...defaultSeo.openGraph,
           title: t('seo_title'),


### PR DESCRIPTION
## Summary
- expose base site URL in SEO config
- add canonical links to home and error pages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898afe84d7883309df043f926364dc5