### PR TITLE
feat: add Chinese locale support

### DIFF
--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -9,6 +9,7 @@ export default function LanguageSwitcher() {
   const languages = [
     { code: 'th', label: 'ไทย' },
     { code: 'en', label: 'English' },
+    { code: 'zh', label: '中文' },
   ]
 
   return (

--- a/locales/zh/common.json
+++ b/locales/zh/common.json
@@ -1,0 +1,9 @@
+{
+  "welcome": "欢迎！这是中文主页。",
+  "seo_title": "会计事务所 | 中文",
+  "seo_description": "多语言会计事务所（中文）",
+  "seo_keywords": "会计, 多语言, 中文, 财务服务",
+  "notFound": "未找到页面",
+  "back_home": "返回首页",
+  "internal_error": "服务器内部错误"
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const locales = ["th", "en"];
+const locales = ["th", "en", "zh"];
 const defaultLocale = "th";
 
 export function middleware(req: NextRequest) {

--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   i18n: {
     defaultLocale: 'th',
-    locales: ['th', 'en'],
+    locales: ['th', 'en', 'zh'],
   },
   localePath: './locales',
 }

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -4,6 +4,6 @@ module.exports = {
   generateRobotsTxt: true,
   i18n: {
     defaultLocale: 'th',
-    locales: ['th', 'en'],
+    locales: ['th', 'en', 'zh'],
   },
 };


### PR DESCRIPTION
## Summary
- add Chinese (`zh`) locale to i18n config, middleware, and sitemap
- add Chinese option to language switcher
- provide Chinese translations with SEO keywords

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_68b68de81aac832bbbbd1c35e5a46c25