### PR TITLE
Use router locales for dynamic language options

### DIFF
--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -1,31 +1,29 @@
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
+const localeLabels: Record<string, string> = {
+  th: 'ไทย',
+  en: 'English',
+  zh: '中文',
+}
+
 export default function LanguageSwitcher() {
   const router = useRouter()
-  const { locale, defaultLocale, pathname, query } = router
-
-  // ลิสต์ภาษา
-  const languages = [
-    { code: 'th', label: 'ไทย' },
-    { code: 'en', label: 'English' },
-    { code: 'zh', label: '中文' },
-  ]
+  const { locale, defaultLocale, pathname, query, locales } = router
 
   return (
     <div>
-      {languages.map((lang) => (
+      {(locales ?? []).map((code) => (
         <Link
-          key={lang.code}
+          key={code}
           href={{ pathname, query }}
-          locale={lang.code}
+          locale={code}
           style={{
             marginRight: 8,
-            fontWeight:
-              (locale ?? defaultLocale) === lang.code ? 'bold' : 'normal'
+            fontWeight: (locale ?? defaultLocale) === code ? 'bold' : 'normal'
           }}
         >
-          {lang.label}
+          {localeLabels[code] ?? code}
         </Link>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- Generate language links from `router.locales` for automatic locale coverage
- Display locale labels via mapping for Thai, English, and Chinese codes

## Testing
- `npm test` *(fails: Invalid project directory provided, no such directory: /workspace/multi-lang-virintira/test)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b693a80440832b89727e1fa0560f2d