### PR TITLE
feat: add Chinese SEO metadata

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -11,7 +11,8 @@ export default function Custom404() {
   const { locale, defaultLocale } = useRouter();
   const lang =
     locale ?? defaultLocale ?? nextI18NextConfig.i18n.defaultLocale;
-  const ogLocale = lang === "en" ? "en_US" : "th_TH";
+  const ogLocale =
+    lang === "en" ? "en_US" : lang === "zh" ? "zh_CN" : "th_TH";
   const baseUrl = defaultSeo.baseUrl;
   const pageUrl =
     lang === defaultLocale
@@ -27,6 +28,12 @@ export default function Custom404() {
           locale: ogLocale,
           url: pageUrl,
         }}
+        languageAlternates={[
+          { hrefLang: 'th', href: `${baseUrl}/th/404` },
+          { hrefLang: 'en', href: `${baseUrl}/en/404` },
+          { hrefLang: 'zh', href: `${baseUrl}/zh/404` },
+          { hrefLang: 'x-default', href: `${baseUrl}/404` },
+        ]}
       />
       <div style={{ textAlign: "center", marginTop: "2rem" }}>
         <h1>404</h1>

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -11,7 +11,8 @@ export default function Custom500() {
   const { locale, defaultLocale } = useRouter();
   const lang =
     locale ?? defaultLocale ?? nextI18NextConfig.i18n.defaultLocale;
-  const ogLocale = lang === "en" ? "en_US" : "th_TH";
+  const ogLocale =
+    lang === "en" ? "en_US" : lang === "zh" ? "zh_CN" : "th_TH";
   const baseUrl = defaultSeo.baseUrl;
   const pageUrl =
     lang === defaultLocale
@@ -27,6 +28,12 @@ export default function Custom500() {
           locale: ogLocale,
           url: pageUrl,
         }}
+        languageAlternates={[
+          { hrefLang: 'th', href: `${baseUrl}/th/500` },
+          { hrefLang: 'en', href: `${baseUrl}/en/500` },
+          { hrefLang: 'zh', href: `${baseUrl}/zh/500` },
+          { hrefLang: 'x-default', href: `${baseUrl}/500` },
+        ]}
       />
       <div style={{ textAlign: "center", marginTop: "2rem" }}>
         <h1>500</h1>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,7 +10,8 @@ export default function Home() {
   const { t } = useTranslation('common')
   const { asPath, defaultLocale } = useRouter()
   const lang = asPath.split('/')[1] || defaultLocale || 'th'
-  const ogLocale = lang === 'en' ? 'en_US' : 'th_TH'
+  const ogLocale =
+    lang === 'en' ? 'en_US' : lang === 'zh' ? 'zh_CN' : 'th_TH'
   const baseUrl = defaultSeo.baseUrl
   const pageUrl = lang === defaultLocale ? baseUrl : `${baseUrl}/${lang}`
   return (
@@ -29,6 +30,7 @@ export default function Home() {
         languageAlternates={[
           { hrefLang: 'th', href: `${baseUrl}/th` },
           { hrefLang: 'en', href: `${baseUrl}/en` },
+          { hrefLang: 'zh', href: `${baseUrl}/zh` },
           { hrefLang: 'x-default', href: baseUrl },
         ]}
       />


### PR DESCRIPTION
## Summary
- support Chinese locale in Open Graph metadata for all pages
- add zh language alternates for index, 404, and 500 pages

## Testing
- `npm test` (fails: Invalid project directory provided, no such directory: /workspace/multi-lang-virintira/test)
- `npm run lint` (fails: ESLint must be installed: npm install --save-dev eslint)


------
https://chatgpt.com/codex/tasks/task_e_68b696aef900832b97317e9661f7feab