### PR TITLE
Add Open Graph images to SEO configuration

### DIFF
--- a/next-seo.config.js
+++ b/next-seo.config.js
@@ -12,6 +12,20 @@ const config = {
     locale: 'th_TH',
     url: siteUrl,
     site_name: 'Virintira',
+    images: [
+      {
+        url: `${siteUrl}og-image.png`,
+        width: 1845,
+        height: 871,
+        alt: 'Virintira Open Graph Image',
+      },
+      {
+        url: `${siteUrl}favicon.ico`,
+        width: 256,
+        height: 256,
+        alt: 'Virintira Favicon',
+      },
+    ],
   },
   twitter: {
     handle: '@virintira',


### PR DESCRIPTION
## Summary
- include OG image and favicon metadata in Open Graph settings for better sharing previews

## Testing
- `npm test` (fails: Invalid project directory provided, no such directory: /workspace/multi-lang-virintira/test)
- `npm run lint` (fails: Invalid Options: - Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)


------
https://chatgpt.com/codex/tasks/task_e_68b6eea53ecc832b989e1af5597df28a