### PR TITLE
feat: add alternate Open Graph locales

### DIFF
--- a/next-seo.config.js
+++ b/next-seo.config.js
@@ -10,6 +10,7 @@ const config = {
   openGraph: {
     type: 'website',
     locale: 'th_TH',
+    localeAlternate: ['th_TH', 'en_US', 'zh_CN'],
     url: siteUrl,
     site_name: 'Virintira',
     images: [


### PR DESCRIPTION
## Summary
- add `localeAlternate` in Open Graph SEO config for Thai, English, and Chinese

## Testing
- `npm test` *(fails: Invalid project directory provided)*
- `npm run lint` *(fails: Invalid options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f0340028832b8ed590b8c663cca8