### PR TITLE
feat: redirect based on accept language

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -3,6 +3,27 @@ import { NextRequest, NextResponse } from "next/server";
 const locales = ["th", "en", "zh"];
 const defaultLocale = "th";
 
+function getPreferredLocale(header: string | null) {
+  if (!header) return defaultLocale;
+
+  const languages = header
+    .split(",")
+    .map((part) => {
+      const [lang, qValue] = part.trim().split(";q=");
+      return {
+        lang: lang.toLowerCase().split("-")[0],
+        q: qValue ? parseFloat(qValue) : 1,
+      };
+    })
+    .sort((a, b) => b.q - a.q);
+
+  for (const { lang } of languages) {
+    if (locales.includes(lang)) return lang;
+  }
+
+  return defaultLocale;
+}
+
 export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
 
@@ -10,16 +31,17 @@ export function middleware(req: NextRequest) {
     pathname.startsWith("/_next") ||
     pathname.startsWith("/api") ||
     pathname === "/favicon.ico"
-  ) return NextResponse.next();
+  )
+    return NextResponse.next();
 
   const pathLocale = pathname.split("/")[1];
   if (locales.includes(pathLocale)) {
     return NextResponse.next();
   }
 
-  // Always redirect to the default locale.
-  // Previous versions inspected the Accept-Language header to pick a locale.
-  const redirectLocale = defaultLocale;
+  const redirectLocale = getPreferredLocale(
+    req.headers.get("accept-language")
+  );
 
   return NextResponse.redirect(new URL(`/${redirectLocale}${pathname}`, req.url));
 }


### PR DESCRIPTION
## Summary
- parse `accept-language` header to determine preferred locale
- redirect to best match when no locale is present, defaulting to Thai

## Testing
- `npm test` (fails: Invalid project directory provided, no such directory: /workspace/multi-lang-virintira/test)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7a8724ae8832bb385dcb09166b031