### PR TITLE
Use router locale for canonical URLs

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,8 +8,8 @@ import LanguageSwitcher from "./../components/LanguageSwitcher"
 
 export default function Home() {
   const { t } = useTranslation('common')
-  const { asPath, defaultLocale } = useRouter()
-  const lang = asPath.split('/')[1] || defaultLocale || 'th'
+  const { locale, defaultLocale } = useRouter()
+  const lang = locale || defaultLocale || 'th'
   const keywords = t('seo_keywords', { returnObjects: true }) as string[]
   const ogLocale =
     lang === 'en' ? 'en_US' : lang === 'zh' ? 'zh_CN' : 'th_TH'

--- a/pages/services/bookkeeping.tsx
+++ b/pages/services/bookkeeping.tsx
@@ -9,8 +9,8 @@ import ServiceJsonLd from '../../components/ServiceJsonLd'
 
 export default function Bookkeeping() {
   const { t } = useTranslation('common')
-  const { asPath, defaultLocale } = useRouter()
-  const lang = asPath.split('/')[1] || defaultLocale || 'th'
+  const { locale, defaultLocale } = useRouter()
+  const lang = locale || defaultLocale || 'th'
   const baseUrl = defaultSeo.baseUrl
   const pageUrl =
     lang === defaultLocale


### PR DESCRIPTION
## Summary
- derive language from `router.locale` instead of splitting `asPath`
- build canonical URLs using locale, avoiding malformed paths

## Testing
- `npm test` *(fails: Invalid project directory provided, no such directory)*
- `npm run lint` *(fails: Invalid Options: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a9d2e438832ba1227bc364cdbab8