### PR TITLE
chore: use locale-specific canonical URLs

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -14,11 +14,8 @@ export default function Custom404() {
   const keywords = t('seo_keywords', { returnObjects: true }) as string[];
   const ogLocale =
     lang === "en" ? "en_US" : lang === "zh" ? "zh_CN" : "th_TH";
-  const baseUrl = defaultSeo.baseUrl;
-  const pageUrl =
-    lang === defaultLocale
-      ? `${baseUrl}/404`
-      : `${baseUrl}/${lang}/404`;
+  const baseUrl = defaultSeo.baseUrl.replace(/\/$/, "");
+  const pageUrl = `${baseUrl}/${lang}/404`;
   return (
     <>
       <NextSeo
@@ -37,7 +34,7 @@ export default function Custom404() {
           { hrefLang: 'th', href: `${baseUrl}/th/404` },
           { hrefLang: 'en', href: `${baseUrl}/en/404` },
           { hrefLang: 'zh', href: `${baseUrl}/zh/404` },
-          { hrefLang: 'x-default', href: `${baseUrl}/404` },
+          { hrefLang: 'x-default', href: `${baseUrl}/th/404` },
         ]}
       />
       <div style={{ textAlign: "center", marginTop: "2rem" }}>

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -14,11 +14,8 @@ export default function Custom500() {
   const keywords = t('seo_keywords', { returnObjects: true }) as string[];
   const ogLocale =
     lang === "en" ? "en_US" : lang === "zh" ? "zh_CN" : "th_TH";
-  const baseUrl = defaultSeo.baseUrl;
-  const pageUrl =
-    lang === defaultLocale
-      ? `${baseUrl}/500`
-      : `${baseUrl}/${lang}/500`;
+  const baseUrl = defaultSeo.baseUrl.replace(/\/$/, "");
+  const pageUrl = `${baseUrl}/${lang}/500`;
   return (
     <>
       <NextSeo
@@ -37,7 +34,7 @@ export default function Custom500() {
           { hrefLang: 'th', href: `${baseUrl}/th/500` },
           { hrefLang: 'en', href: `${baseUrl}/en/500` },
           { hrefLang: 'zh', href: `${baseUrl}/zh/500` },
-          { hrefLang: 'x-default', href: `${baseUrl}/500` },
+          { hrefLang: 'x-default', href: `${baseUrl}/th/500` },
         ]}
       />
       <div style={{ textAlign: "center", marginTop: "2rem" }}>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,12 +5,13 @@ import * as NextSeo from "next-seo";
 import defaultSeo from "../next-seo.config";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  const baseUrl = defaultSeo.baseUrl;
+  const baseUrl = defaultSeo.baseUrl.replace(/\/$/, '');
+  const siteUrl = `${baseUrl}/th`;
   const orgJsonLd = {
     "@context": "https://schema.org",
     "@type": "Organization",
     name: "Virintira",
-    url: baseUrl,
+    url: siteUrl,
     logo: `${baseUrl}/favicon.ico`,
     sameAs: [
       "https://twitter.com/virintira",
@@ -22,7 +23,7 @@ function MyApp({ Component, pageProps }: AppProps) {
     "@context": "https://schema.org",
     "@type": "WebSite",
     name: "Virintira",
-    url: baseUrl,
+    url: siteUrl,
   };
 
   const { JsonLd: NextSeoJsonLd } = NextSeo as any;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -20,8 +20,9 @@ export default function Home() {
   const keywords = t('seo_keywords', { returnObjects: true }) as string[]
   const ogLocale =
     lang === 'en' ? 'en_US' : lang === 'zh' ? 'zh_CN' : 'th_TH'
-  const baseUrl = defaultSeo.baseUrl
-  const pageUrl = lang === defaultLocale ? baseUrl : `${baseUrl}/${lang}`
+  const baseUrl = defaultSeo.baseUrl.replace(/\/$/, '')
+  const siteUrl = `${baseUrl}/th`
+  const pageUrl = `${baseUrl}/${lang}`
   return (
     <>
       <NextSeo
@@ -43,7 +44,7 @@ export default function Home() {
           { hrefLang: 'th', href: `${baseUrl}/th` },
           { hrefLang: 'en', href: `${baseUrl}/en` },
           { hrefLang: 'zh', href: `${baseUrl}/zh` },
-          { hrefLang: 'x-default', href: baseUrl },
+          { hrefLang: 'x-default', href: `${baseUrl}/th` },
         ]}
       />
       <WebPageJsonLd
@@ -61,10 +62,10 @@ export default function Home() {
       />
       <LocalBusinessJsonLd
         type='AccountingService'
-        id={baseUrl}
+        id={siteUrl}
         name='Virintira'
         description='Multilingual accounting partner.'
-        url={baseUrl}
+        url={siteUrl}
         telephone='+66-2-123-4567'
         address={{
           streetAddress: '123 Example Road',
@@ -81,10 +82,10 @@ export default function Home() {
         }]}
       />
       <SiteLinksSearchBoxJsonLd
-        url={baseUrl}
+        url={siteUrl}
         potentialActions={[
           {
-            target: `${baseUrl}/search?query={search_term_string}`,
+            target: `${siteUrl}/search?query={search_term_string}`,
             queryInput: 'search_term_string',
           },
         ]}

--- a/pages/services/bookkeeping.tsx
+++ b/pages/services/bookkeeping.tsx
@@ -16,12 +16,10 @@ export default function Bookkeeping() {
   const { t } = useTranslation('common')
   const { locale, defaultLocale } = useRouter()
   const lang = locale || defaultLocale || 'th'
-  const baseUrl = defaultSeo.baseUrl
-  const homeUrl = lang === defaultLocale ? baseUrl : `${baseUrl}/${lang}`
-  const pageUrl =
-    lang === defaultLocale
-      ? `${baseUrl}/services/bookkeeping`
-      : `${baseUrl}/${lang}/services/bookkeeping`
+  const baseUrl = defaultSeo.baseUrl.replace(/\/$/, '')
+  const siteUrl = `${baseUrl}/th`
+  const homeUrl = `${baseUrl}/${lang}`
+  const pageUrl = `${baseUrl}/${lang}/services/bookkeeping`
   return (
     <>
       <NextSeo
@@ -58,7 +56,7 @@ export default function Bookkeeping() {
       <ServiceJsonLd
         name={t('bookkeeping_service_name')}
         description={t('bookkeeping_service_description')}
-        provider={{ '@type': 'Organization', name: 'Virintira', url: baseUrl }}
+        provider={{ '@type': 'Organization', name: 'Virintira', url: siteUrl }}
         url={pageUrl}
       />
       <FAQPageJsonLd


### PR DESCRIPTION
## Summary
- compute canonical URLs with explicit locale segments
- align `languageAlternates` with locale-aware canonicals
- point JSON-LD site metadata to default locale path

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7c3f97914832bae0e43262f1e50d9