### PR TITLE
Add robots noindex and nofollow meta to error pages

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -21,15 +21,16 @@ export default function Custom404() {
       <NextSeo
         title={`404 - ${t("seo_title")}`}
         canonical={pageUrl}
+        noindex
+        nofollow
         openGraph={{
           ...defaultSeo.openGraph,
           locale: ogLocale,
           url: pageUrl,
         }}
-        additionalMetaTags={[{
-          name: 'keywords',
-          content: keywords.join(', '),
-        }]}
+        additionalMetaTags={[
+          { name: 'keywords', content: keywords.join(', ') },
+        ]}
         languageAlternates={[
           { hrefLang: 'th', href: `${baseUrl}/th/404` },
           { hrefLang: 'en', href: `${baseUrl}/en/404` },

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -21,15 +21,16 @@ export default function Custom500() {
       <NextSeo
         title={`500 - ${t("seo_title")}`}
         canonical={pageUrl}
+        noindex
+        nofollow
         openGraph={{
           ...defaultSeo.openGraph,
           locale: ogLocale,
           url: pageUrl,
         }}
-        additionalMetaTags={[{
-          name: 'keywords',
-          content: keywords.join(', '),
-        }]}
+        additionalMetaTags={[
+          { name: 'keywords', content: keywords.join(', ') },
+        ]}
         languageAlternates={[
           { hrefLang: 'th', href: `${baseUrl}/th/500` },
           { hrefLang: 'en', href: `${baseUrl}/en/500` },


### PR DESCRIPTION
## Summary
- prevent search engines from indexing 404 and 500 pages by adding noindex and nofollow directives via NextSeo

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `rg -o 'meta name="robots"[^>]*>' .next/server/pages/en/404.html`
- `rg -o 'meta name="robots"[^>]*>' .next/server/pages/en/500.html`


------
https://chatgpt.com/codex/tasks/task_e_68b7c51d7628832ba99e7aabc48fc7fe