### PR TITLE
fix: exclude default locale from Open Graph alternates

### DIFF
--- a/next-seo.config.js
+++ b/next-seo.config.js
@@ -10,7 +10,8 @@ const config = {
   openGraph: {
     type: 'website',
     locale: 'th_TH',
-    localeAlternate: ['th_TH', 'en_US', 'zh_CN'],
+    // List alternates excluding the default locale
+    localeAlternate: ['en_US', 'zh_CN'],
     url: siteUrl,
     site_name: 'Virintira',
     images: [


### PR DESCRIPTION
## Summary
- ensure Open Graph `localeAlternate` excludes default Thai locale

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7d564bd58832bb4d459e476f8c86c