### PR TITLE
Add JsonLd typing for next-seo

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,6 @@
 import "../styles/globals.css";
 import type { AppProps } from "next/app";
 import { appWithTranslation } from "next-i18next";
-// @ts-ignore - JsonLd types are not exported from next-seo
 import { DefaultSeo, JsonLd } from "next-seo";
 import { useRouter } from "next/router";
 import { buildUrl } from "../lib/url";

--- a/types/next-seo.d.ts
+++ b/types/next-seo.d.ts
@@ -1,0 +1,12 @@
+import type { ComponentType } from 'react';
+
+declare module 'next-seo' {
+  export interface JsonLdProps {
+    scriptKey: string;
+    scriptId: string;
+    [key: string]: unknown;
+  }
+
+  export const JsonLd: ComponentType<JsonLdProps>;
+}
+


### PR DESCRIPTION
## Summary
- add local JsonLdProps interface and module augmentation for next-seo
- remove ts-ignore and use typed JsonLd in _app

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build` *(fails: "Attempted import error: 'JsonLd' is not exported from 'next-seo'")*


------
https://chatgpt.com/codex/tasks/task_e_68b7d8053ef4832b81cab4217faf66c2