### PR TITLE
refactor: centralize SEO helpers

### DIFF
--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,0 +1,27 @@
+import defaultSeo from '../next-seo.config'
+import { buildUrl } from './url'
+
+export const getSeoUrls = (lang: string, path = '') => buildUrl(lang, path)
+
+const ogLocaleMap: Record<string, string> = { en: 'en_US', zh: 'zh_CN', th: 'th_TH' }
+
+export const getOpenGraph = (
+  lang: string,
+  url: string,
+  title?: string,
+  description?: string
+) => ({
+  ...defaultSeo.openGraph,
+  ...(title && { title }),
+  ...(description && { description }),
+  locale: ogLocaleMap[lang] || ogLocaleMap.th,
+  url,
+})
+
+export const getLanguageAlternates = (path = '') => [
+  { hrefLang: 'th', href: getSeoUrls('th', path).pageUrl },
+  { hrefLang: 'en', href: getSeoUrls('en', path).pageUrl },
+  { hrefLang: 'zh', href: getSeoUrls('zh', path).pageUrl },
+  { hrefLang: 'x-default', href: getSeoUrls('th', path).pageUrl },
+]
+

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -4,8 +4,7 @@ import { NextSeo } from "next-seo";
 import { useRouter } from "next/router";
 import { GetStaticProps } from "next";
 import nextI18NextConfig from "../next-i18next.config";
-import defaultSeo from "../next-seo.config";
-import { buildUrl } from "../lib/url";
+import { getOpenGraph, getLanguageAlternates, getSeoUrls } from "../lib/seo";
 
 export default function Custom404() {
   const { t } = useTranslation("common");
@@ -13,9 +12,7 @@ export default function Custom404() {
   const lang =
     locale ?? defaultLocale ?? nextI18NextConfig.i18n.defaultLocale;
   const keywords = t('seo_keywords', { returnObjects: true }) as string[];
-  const ogLocale =
-    lang === "en" ? "en_US" : lang === "zh" ? "zh_CN" : "th_TH";
-  const { pageUrl } = buildUrl(lang, "/404");
+  const { pageUrl } = getSeoUrls(lang, "/404");
   return (
     <>
       <NextSeo
@@ -23,20 +20,11 @@ export default function Custom404() {
         canonical={pageUrl}
         noindex
         nofollow
-        openGraph={{
-          ...defaultSeo.openGraph,
-          locale: ogLocale,
-          url: pageUrl,
-        }}
+        openGraph={getOpenGraph(lang, pageUrl)}
         additionalMetaTags={[
           { name: 'keywords', content: keywords.join(', ') },
         ]}
-        languageAlternates={[
-          { hrefLang: 'th', href: buildUrl('th', '/404').pageUrl },
-          { hrefLang: 'en', href: buildUrl('en', '/404').pageUrl },
-          { hrefLang: 'zh', href: buildUrl('zh', '/404').pageUrl },
-          { hrefLang: 'x-default', href: buildUrl('th', '/404').pageUrl },
-        ]}
+        languageAlternates={getLanguageAlternates('/404')}
       />
       <div style={{ textAlign: "center", marginTop: "2rem" }}>
         <h1>404</h1>

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -4,8 +4,7 @@ import { NextSeo } from "next-seo";
 import { useRouter } from "next/router";
 import { GetStaticProps } from "next";
 import nextI18NextConfig from "../next-i18next.config";
-import defaultSeo from "../next-seo.config";
-import { buildUrl } from "../lib/url";
+import { getOpenGraph, getLanguageAlternates, getSeoUrls } from "../lib/seo";
 
 export default function Custom500() {
   const { t } = useTranslation("common");
@@ -13,9 +12,7 @@ export default function Custom500() {
   const lang =
     locale ?? defaultLocale ?? nextI18NextConfig.i18n.defaultLocale;
   const keywords = t('seo_keywords', { returnObjects: true }) as string[];
-  const ogLocale =
-    lang === "en" ? "en_US" : lang === "zh" ? "zh_CN" : "th_TH";
-  const { pageUrl } = buildUrl(lang, "/500");
+  const { pageUrl } = getSeoUrls(lang, "/500");
   return (
     <>
       <NextSeo
@@ -23,20 +20,11 @@ export default function Custom500() {
         canonical={pageUrl}
         noindex
         nofollow
-        openGraph={{
-          ...defaultSeo.openGraph,
-          locale: ogLocale,
-          url: pageUrl,
-        }}
+        openGraph={getOpenGraph(lang, pageUrl)}
         additionalMetaTags={[
           { name: 'keywords', content: keywords.join(', ') },
         ]}
-        languageAlternates={[
-          { hrefLang: 'th', href: buildUrl('th', '/500').pageUrl },
-          { hrefLang: 'en', href: buildUrl('en', '/500').pageUrl },
-          { hrefLang: 'zh', href: buildUrl('zh', '/500').pageUrl },
-          { hrefLang: 'x-default', href: buildUrl('th', '/500').pageUrl },
-        ]}
+        languageAlternates={getLanguageAlternates('/500')}
       />
       <div style={{ textAlign: "center", marginTop: "2rem" }}>
         <h1>500</h1>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,41 +10,32 @@ import {
 } from 'next-seo'
 import { useRouter } from 'next/router'
 import Script from 'next/script'
-import defaultSeo from '../next-seo.config'
 import LanguageSwitcher from "./../components/LanguageSwitcher"
-import { buildUrl } from '../lib/url'
+import { getOpenGraph, getLanguageAlternates, getSeoUrls } from '../lib/seo'
 
 export default function Home() {
   const { t } = useTranslation('common')
   const { locale, defaultLocale } = useRouter()
   const lang = locale || defaultLocale || 'th'
   const keywords = t('seo_keywords', { returnObjects: true }) as string[]
-  const ogLocale =
-    lang === 'en' ? 'en_US' : lang === 'zh' ? 'zh_CN' : 'th_TH'
-  const { baseUrl, siteUrl, pageUrl } = buildUrl(lang)
+  const { baseUrl, siteUrl, pageUrl } = getSeoUrls(lang)
   return (
     <>
       <NextSeo
         title={t('seo_title')}
         description={t('seo_description')}
         canonical={pageUrl}
-        openGraph={{
-          ...defaultSeo.openGraph,
-          title: t('seo_title'),
-          description: t('seo_description'),
-          locale: ogLocale,
-          url: pageUrl,
-        }}
+        openGraph={getOpenGraph(
+          lang,
+          pageUrl,
+          t('seo_title'),
+          t('seo_description')
+        )}
         additionalMetaTags={[{
           name: 'keywords',
           content: keywords.join(', '),
         }]}
-        languageAlternates={[
-          { hrefLang: 'th', href: buildUrl('th').siteUrl },
-          { hrefLang: 'en', href: buildUrl('en').siteUrl },
-          { hrefLang: 'zh', href: buildUrl('zh').siteUrl },
-          { hrefLang: 'x-default', href: buildUrl('th').siteUrl },
-        ]}
+        languageAlternates={getLanguageAlternates()}
       />
       <WebPageJsonLd
         id={pageUrl}

--- a/pages/services/bookkeeping.tsx
+++ b/pages/services/bookkeeping.tsx
@@ -8,18 +8,16 @@ import {
   WebPageJsonLd,
   BreadcrumbJsonLd,
 } from 'next-seo'
-import defaultSeo from '../../next-seo.config'
 import LanguageSwitcher from '../../components/LanguageSwitcher'
 import ServiceJsonLd from '../../components/ServiceJsonLd'
-import { buildUrl } from '../../lib/url'
+import { getOpenGraph, getLanguageAlternates, getSeoUrls } from '../../lib/seo'
 
 export default function Bookkeeping() {
   const { t } = useTranslation('common')
   const { locale, defaultLocale } = useRouter()
   const lang = locale || defaultLocale || 'th'
   const keywords = t('bookkeeping_service_keywords', { returnObjects: true }) as string[]
-  const ogLocale = lang === 'en' ? 'en_US' : lang === 'zh' ? 'zh_CN' : 'th_TH'
-  const { baseUrl, siteUrl, pageUrl } = buildUrl(lang, '/services/bookkeeping')
+  const { baseUrl, siteUrl, pageUrl } = getSeoUrls(lang, '/services/bookkeeping')
   const homeUrl = siteUrl
   return (
     <>
@@ -27,25 +25,19 @@ export default function Bookkeeping() {
         title={t('bookkeeping_service_name')}
         description={t('bookkeeping_service_description')}
         canonical={pageUrl}
-        openGraph={{
-          ...defaultSeo.openGraph,
-          title: t('bookkeeping_service_name'),
-          description: t('bookkeeping_service_description'),
-          locale: ogLocale,
-          url: pageUrl,
-        }}
+        openGraph={getOpenGraph(
+          lang,
+          pageUrl,
+          t('bookkeeping_service_name'),
+          t('bookkeeping_service_description')
+        )}
         additionalMetaTags={[
           {
             name: 'keywords',
             content: keywords.join(', '),
           },
         ]}
-        languageAlternates={[
-          { hrefLang: 'th', href: buildUrl('th', '/services/bookkeeping').pageUrl },
-          { hrefLang: 'en', href: buildUrl('en', '/services/bookkeeping').pageUrl },
-          { hrefLang: 'zh', href: buildUrl('zh', '/services/bookkeeping').pageUrl },
-          { hrefLang: 'x-default', href: buildUrl('th', '/services/bookkeeping').pageUrl },
-        ]}
+        languageAlternates={getLanguageAlternates('/services/bookkeeping')}
       />
       <WebPageJsonLd
         id={pageUrl}


### PR DESCRIPTION
## Summary
- add seo utilities for canonical URLs, OpenGraph data, and language alternates
- refactor pages to consume centralized SEO helpers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7dafb0ecc832b8bfbeac519871cba