### PR TITLE
chore: add negotiator typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       },
       "devDependencies": {
         "@testing-library/react": "^16.3.0",
+        "@types/negotiator": "^0.6.4",
         "@types/node": "^20.19.8",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",
@@ -1987,6 +1988,13 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@types/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-elf6BsTq+AkyNsb2h5cGNst2Mc7dPliVoAPm1fXglC/BM3f2pFA40BaSSv3E5lyHteEawVKLP+8TwiY1DMNb3A==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",
+    "@types/negotiator": "^0.6.4",
     "@types/node": "^20.19.8",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",


### PR DESCRIPTION
## Summary
- add `@types/negotiator` dev dependency to fix missing type definitions

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7e00bb5e0832b8de973afa803e698