### PR TITLE
Add alternate language references to sitemap

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -6,4 +6,9 @@ module.exports = {
     defaultLocale: 'th',
     locales: ['th', 'en', 'zh'],
   },
+  alternateRefs: [
+    { href: 'https://www.virintira.com/th', hreflang: 'th' },
+    { href: 'https://www.virintira.com/en', hreflang: 'en' },
+    { href: 'https://www.virintira.com/zh', hreflang: 'zh' },
+  ],
 };


### PR DESCRIPTION
## Summary
- add `alternateRefs` for Thai, English, and Chinese locales in `next-sitemap.config.js`
- generate sitemap to confirm alternate language links

## Testing
- `npm run build`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7e0bca428832b907bfd87a24661f1