### PR TITLE
Add publisher metadata to bookkeeping article

### DIFF
--- a/pages/blog/bookkeeping-matters.tsx
+++ b/pages/blog/bookkeeping-matters.tsx
@@ -66,6 +66,8 @@ export default function BookkeepingMatters() {
         dateModified="2023-01-01"
         authorName={t('blog_post_author')}
         description={t('blog_post_description')}
+        publisherName="Virintira"
+        publisherLogo={`${baseUrl}/favicon.ico`}
       />
       <LanguageSwitcher />
       <h1>{t('blog_post_title')}</h1>


### PR DESCRIPTION
## Summary
- include publisher name and logo in bookkeeping article JSON-LD

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7ec321308832bbf0cd4e1de42e198