### PR TITLE
feat: add speakable schema to bookkeeping pages

### DIFF
--- a/pages/blog/bookkeeping-matters.tsx
+++ b/pages/blog/bookkeeping-matters.tsx
@@ -8,6 +8,7 @@ import {
   WebPageJsonLd,
   BreadcrumbJsonLd,
 } from 'next-seo'
+import Script from 'next/script'
 import LanguageSwitcher from '../../components/LanguageSwitcher'
 import { getOpenGraph, getLanguageAlternates, getSeoUrls } from '../../lib/seo'
 
@@ -68,6 +69,24 @@ export default function BookkeepingMatters() {
         description={t('blog_post_description')}
         publisherName="Virintira"
         publisherLogo={`${baseUrl}/favicon.ico`}
+      />
+      {/* eslint-disable-next-line react/no-danger */}
+      <Script
+        id='speakable'
+        type='application/ld+json'
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'WebPage',
+            name: t('blog_post_title'),
+            description: t('blog_post_description'),
+            url: pageUrl,
+            speakable: {
+              '@type': 'SpeakableSpecification',
+              cssSelector: ['h1', 'p'],
+            },
+          }).replace(/</g, '\\u003c'),
+        }}
       />
       <LanguageSwitcher />
       <h1>{t('blog_post_title')}</h1>

--- a/pages/services/bookkeeping.tsx
+++ b/pages/services/bookkeeping.tsx
@@ -8,6 +8,7 @@ import {
   WebPageJsonLd,
   BreadcrumbJsonLd,
 } from 'next-seo'
+import Script from 'next/script'
 import LanguageSwitcher from '../../components/LanguageSwitcher'
 import ServiceJsonLd from '../../components/ServiceJsonLd'
 import { getOpenGraph, getLanguageAlternates, getSeoUrls } from '../../lib/seo'
@@ -73,6 +74,24 @@ export default function Bookkeeping() {
             acceptedAnswerText: t('faq_answer_1'),
           },
         ]}
+      />
+      {/* eslint-disable-next-line react/no-danger */}
+      <Script
+        id='speakable'
+        type='application/ld+json'
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'WebPage',
+            name: t('bookkeeping_service_name'),
+            description: t('bookkeeping_service_description'),
+            url: pageUrl,
+            speakable: {
+              '@type': 'SpeakableSpecification',
+              cssSelector: ['h1', 'h2', 'p'],
+            },
+          }).replace(/</g, '\\u003c'),
+        }}
       />
       <LanguageSwitcher />
       <h1>{t('bookkeeping_service_name')}</h1>


### PR DESCRIPTION
## Summary
- add SpeakableSpecification JSON-LD to bookkeeping blog post
- add SpeakableSpecification JSON-LD to bookkeeping service page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7ecd9af40832b8e46cc681c7cf24c