### PR TITLE
Use permanent redirect in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -39,7 +39,10 @@ export function middleware(req: NextRequest) {
     req.headers.get("accept-language")
   );
 
-  return NextResponse.redirect(new URL(`/${redirectLocale}${pathname}`, req.url));
+  return NextResponse.redirect(
+    new URL(`/${redirectLocale}${pathname}`, req.url),
+    308
+  );
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- add 308 status to middleware redirects for permanent link

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7f32d8c2c832b9d8641064367571b