### PR TITLE
feat: add area served to service json-ld

### DIFF
--- a/components/ServiceJsonLd.tsx
+++ b/components/ServiceJsonLd.tsx
@@ -6,10 +6,16 @@ interface Provider {
   url?: string
 }
 
+interface AreaServed {
+  '@type': string
+  name: string
+}
+
 export interface ServiceJsonLdProps {
   name: string
   description: string
   provider: Provider
+  areaServed?: AreaServed
   type?: string
   url?: string
   id?: string
@@ -20,6 +26,7 @@ export default function ServiceJsonLd({
   name,
   description,
   provider,
+  areaServed,
   url,
   id = 'service-jsonld',
 }: ServiceJsonLdProps) {
@@ -29,6 +36,7 @@ export default function ServiceJsonLd({
     name,
     description,
     provider,
+    ...(areaServed ? { areaServed } : {}),
     ...(url ? { url } : {}),
   }
 

--- a/pages/services/bookkeeping.tsx
+++ b/pages/services/bookkeeping.tsx
@@ -75,6 +75,7 @@ export default function Bookkeeping() {
         name={t('bookkeeping_service_name')}
         description={t('bookkeeping_service_description')}
         provider={{ '@type': 'Organization', name: 'Virintira', url: siteUrl }}
+        areaServed={{ '@type': 'AdministrativeArea', name: 'Bangkok' }}
         url={pageUrl}
       />
       <FAQPageJsonLd


### PR DESCRIPTION
## Summary
- allow ServiceJsonLd component to include `areaServed`
- supply Bangkok as the service area on bookkeeping page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7f45166f0832bbe9652742d997316