### PR TITLE
Fix metadata message loading for localized pages

### DIFF
--- a/app/[locale]/(pages)/page.tsx
+++ b/app/[locale]/(pages)/page.tsx
@@ -1,0 +1,252 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { COMPANY } from "@/data/company";
+import { absoluteUrl } from "@/config/site";
+import { buildLocaleAlternates } from "@/lib/metadata";
+import { JsonLd } from "@/components/common/JsonLd";
+import { loadMessages, resolveLocale } from "@/i18n/loadMessages";
+import { buildBreadcrumbJsonLd, buildWebPageJsonLd } from "@/seo/jsonld";
+
+interface PageParams {
+  params: { locale: string };
+}
+
+export async function generateMetadata({ params }: PageParams): Promise<Metadata> {
+  const locale = resolveLocale(params.locale);
+  const messages = (await loadMessages(locale)) as any;
+  const meta = messages.metadata.home as { title: string; description: string; keywords: string[] };
+  const path = `/${locale}`;
+
+  return {
+    title: meta.title,
+    description: meta.description,
+    keywords: meta.keywords,
+    alternates: {
+      canonical: absoluteUrl(path),
+      languages: buildLocaleAlternates(""),
+    },
+    openGraph: {
+      title: meta.title,
+      description: meta.description,
+      url: absoluteUrl(path),
+      siteName: COMPANY.brand,
+      type: "website",
+      locale,
+      images: [
+        {
+          url: absoluteUrl(`/${locale}/opengraph-image`),
+          width: 1200,
+          height: 630,
+          alt: meta.title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: meta.title,
+      description: meta.description,
+      images: [absoluteUrl(`/${locale}/opengraph-image`)],
+    },
+  };
+}
+
+export default async function HomePage({ params }: PageParams) {
+  const { locale } = params;
+  const tHome = await getTranslations({ locale, namespace: "home" });
+  const tLayout = await getTranslations({ locale, namespace: "layout" });
+  const tBreadcrumbs = await getTranslations({ locale, namespace: "breadcrumbs" });
+
+  const hero = tHome.raw("hero") as {
+    title: string;
+    subtitle: string;
+    description: string;
+    primary: string;
+    secondary: string;
+  };
+  const about = tHome.raw("about") as {
+    heading: string;
+    paragraphs: string[];
+    link: string;
+  };
+  const services = tHome.raw("services") as {
+    heading: string;
+    items: Array<{ title: string; description: string }>;
+  };
+  const highlights = tHome.raw("highlights") as { heading: string; items: string[] };
+  const process = tHome.raw("process") as {
+    heading: string;
+    steps: Array<{ title: string; description: string }>;
+  };
+  const cta = tHome.raw("cta") as { heading: string; description: string };
+
+  const callLabel = tLayout("cta.call", { phone: COMPANY.phoneDisplay });
+  const chatLabel = tLayout("cta.chat");
+  const consultLabel = tLayout("cta.consult", { phone: COMPANY.phoneDisplay });
+
+  const breadcrumbJsonLd = buildBreadcrumbJsonLd([
+    { name: tBreadcrumbs("home"), path: `/${locale}` },
+  ]);
+  const webPageJsonLd = buildWebPageJsonLd({
+    locale,
+    title: hero.title,
+    description: hero.description,
+    path: `/${locale}`,
+  });
+
+  return (
+    <div className="space-y-24 pb-24">
+      <JsonLd id="jsonld-home" data={webPageJsonLd} />
+      <JsonLd id="jsonld-breadcrumb" data={breadcrumbJsonLd} />
+      <section className="relative overflow-hidden bg-[#FFFEFE]">
+        <div className="absolute inset-0 bg-gradient-to-br from-[#FFFEFE] via-[#FFEDED] to-[#FAD1D1]" aria-hidden="true" />
+        <div className="relative mx-auto flex max-w-6xl flex-col items-center gap-8 px-4 py-24 text-center lg:flex-row lg:items-center lg:justify-between lg:text-left">
+          <div className="max-w-xl space-y-6">
+            <h1 className="text-4xl font-extrabold leading-tight text-[#A70909] sm:text-5xl lg:text-6xl">{hero.title}</h1>
+            <p className="text-xl font-semibold text-[#A70909]">{hero.subtitle}</p>
+            <p className="text-base leading-relaxed text-gray-700 sm:text-lg">{hero.description}</p>
+            <div className="flex flex-col items-center gap-4 pt-4 sm:flex-row sm:justify-start">
+              <a
+                href={`tel:${COMPANY.phone}`}
+                className="inline-flex items-center justify-center rounded-full border-2 border-[#A70909] px-6 py-3 text-sm font-semibold text-[#A70909] transition hover:bg-[#A70909] hover:text-white"
+              >
+                {hero.primary}
+              </a>
+              <a
+                href={COMPANY.socials.line}
+                className="inline-flex items-center justify-center rounded-full bg-[#06C755] px-6 py-3 text-sm font-semibold text-white transition hover:brightness-110"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {chatLabel}
+              </a>
+            </div>
+          </div>
+          <div className="flex max-w-md flex-col items-center gap-4 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-xl backdrop-blur">
+            <p className="text-lg font-semibold text-[#A70909]">{hero.secondary}</p>
+            <p className="text-sm text-gray-600">{COMPANY.legalNameTh}</p>
+            <a
+              href={`mailto:${COMPANY.email}`}
+              className="rounded-full bg-[#A70909] px-6 py-3 text-sm font-semibold text-white transition hover:bg-[#C9341F]"
+            >
+              {hero.secondary}
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-4" id="about">
+        <div className="grid gap-10 lg:grid-cols-[1.2fr_1fr] lg:items-start">
+          <div className="space-y-6">
+            <h2 className="text-3xl font-bold text-[#A70909] sm:text-4xl">{about.heading}</h2>
+            <div className="space-y-4 text-base leading-relaxed text-gray-700">
+              {about.paragraphs.map((paragraph: string, index: number) => (
+                <p key={index} className="indent-6">
+                  {paragraph}
+                </p>
+              ))}
+            </div>
+            <a
+              href={`mailto:${COMPANY.email}`}
+              className="inline-flex w-fit items-center justify-center rounded-full border-2 border-[#A70909] px-5 py-2 text-sm font-semibold text-[#A70909] transition hover:bg-[#A70909] hover:text-white"
+            >
+              {about.link}
+            </a>
+          </div>
+          <div className="flex justify-center">
+            <div className="w-full max-w-sm rounded-3xl border border-[#A70909]/20 bg-white p-6 shadow-lg">
+              <h3 className="text-lg font-semibold text-[#A70909]">{COMPANY.legalNameTh}</h3>
+              <p className="mt-4 space-y-1 text-sm leading-relaxed text-gray-600">
+                <span className="block">Tax ID: {COMPANY.taxId}</span>
+                <span className="block">{COMPANY.address.streetAddress}</span>
+                <span className="block">
+                  {COMPANY.address.subDistrict} {COMPANY.address.district} {COMPANY.address.province} {COMPANY.address.postalCode}
+                </span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-[#fff5f5]" id="services">
+        <div className="mx-auto max-w-6xl px-4 py-16">
+          <h2 className="text-center text-3xl font-bold text-[#A70909] sm:text-4xl">{services.heading}</h2>
+          <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {services.items.map((item, index) => (
+              <div
+                key={item.title}
+                className="flex h-full flex-col rounded-2xl border border-white/60 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
+              >
+                <span className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-full bg-[#A70909]/10 text-[#A70909]">
+                  {index + 1}
+                </span>
+                <h3 className="text-lg font-semibold text-[#A70909]">{item.title}</h3>
+                <p className="mt-3 text-sm leading-relaxed text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-4">
+        <div className="rounded-3xl bg-gradient-to-br from-[#A70909] to-[#6B0606] p-10 text-white">
+          <h2 className="text-center text-3xl font-bold sm:text-4xl">{highlights.heading}</h2>
+          <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {highlights.items.map((item) => (
+              <div key={item} className="rounded-2xl bg-white/10 p-6 text-base font-medium leading-relaxed">
+                {item}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-4" id="process">
+        <div className="space-y-8">
+          <h2 className="text-center text-3xl font-bold text-[#A70909] sm:text-4xl">{process.heading}</h2>
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+            {process.steps.map((step, index) => (
+              <div key={step.title} className="rounded-2xl border border-[#A70909]/20 bg-white p-6 shadow-sm">
+                <span className="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-full bg-[#A70909]/10 text-sm font-semibold text-[#A70909]">
+                  {index + 1}
+                </span>
+                <h3 className="text-lg font-semibold text-[#A70909]">{step.title}</h3>
+                <p className="mt-3 text-sm leading-relaxed text-gray-600">{step.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-[#FFECEC]" id="contact">
+        <div className="mx-auto max-w-6xl px-4 py-16">
+          <div className="flex flex-col items-center gap-6 rounded-3xl bg-white/80 p-10 text-center shadow-lg">
+            <h2 className="text-3xl font-bold text-[#A70909] sm:text-4xl">{cta.heading}</h2>
+            <p className="max-w-2xl text-base leading-relaxed text-gray-700 sm:text-lg">{cta.description}</p>
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <a
+                href={`tel:${COMPANY.phone}`}
+                className="inline-flex min-w-[200px] items-center justify-center rounded-full border-2 border-[#A70909] px-6 py-3 text-sm font-semibold text-[#A70909] transition hover:bg-[#A70909] hover:text-white"
+              >
+                {callLabel}
+              </a>
+              <a
+                href={COMPANY.socials.line}
+                className="inline-flex min-w-[200px] items-center justify-center rounded-full bg-[#06C755] px-6 py-3 text-sm font-semibold text-white transition hover:brightness-110"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {chatLabel}
+              </a>
+              <a
+                href={`mailto:${COMPANY.email}`}
+                className="inline-flex min-w-[200px] items-center justify-center rounded-full bg-[#A70909] px-6 py-3 text-sm font-semibold text-white transition hover:bg-[#C9341F]"
+              >
+                {consultLabel}
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/[locale]/(pages)/promotion/page.tsx
+++ b/app/[locale]/(pages)/promotion/page.tsx
@@ -1,0 +1,123 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { COMPANY } from "@/data/company";
+import { absoluteUrl } from "@/config/site";
+import { buildLocaleAlternates } from "@/lib/metadata";
+import { JsonLd } from "@/components/common/JsonLd";
+import { loadMessages, resolveLocale } from "@/i18n/loadMessages";
+import { buildBreadcrumbJsonLd, buildWebPageJsonLd } from "@/seo/jsonld";
+
+interface PageParams {
+  params: { locale: string };
+}
+
+export async function generateMetadata({ params }: PageParams): Promise<Metadata> {
+  const locale = resolveLocale(params.locale);
+  const messages = (await loadMessages(locale)) as any;
+  const meta = messages.metadata.promotion as { title: string; description: string; keywords: string[] };
+  const path = `/${locale}/promotion`;
+
+  return {
+    title: meta.title,
+    description: meta.description,
+    keywords: meta.keywords,
+    alternates: {
+      canonical: absoluteUrl(path),
+      languages: buildLocaleAlternates("/promotion"),
+    },
+    openGraph: {
+      title: meta.title,
+      description: meta.description,
+      url: absoluteUrl(path),
+      siteName: COMPANY.brand,
+      type: "article",
+      locale,
+      images: [
+        {
+          url: absoluteUrl(`/${locale}/promotion/opengraph-image`),
+          width: 1200,
+          height: 630,
+          alt: meta.title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: meta.title,
+      description: meta.description,
+      images: [absoluteUrl(`/${locale}/promotion/opengraph-image`)],
+    },
+  };
+}
+
+export default async function PromotionPage({ params }: PageParams) {
+  const { locale } = params;
+  const tPromotion = await getTranslations({ locale, namespace: "promotion" });
+  const tBreadcrumbs = await getTranslations({ locale, namespace: "breadcrumbs" });
+
+  const hero = tPromotion.raw("hero") as { title: string; intro: string };
+  const offers = tPromotion.raw("offers") as Array<{ name: string; bullets: string[]; note: string }>;
+  const cta = tPromotion("cta");
+
+  const breadcrumbJsonLd = buildBreadcrumbJsonLd([
+    { name: tBreadcrumbs("home"), path: `/${locale}` },
+    { name: tBreadcrumbs("promotion"), path: `/${locale}/promotion` },
+  ]);
+  const webPageJsonLd = buildWebPageJsonLd({
+    locale,
+    title: hero.title,
+    description: hero.intro,
+    path: `/${locale}/promotion`,
+  });
+
+  return (
+    <div className="space-y-16 pb-20">
+      <JsonLd id="jsonld-promotion" data={webPageJsonLd} />
+      <JsonLd id="jsonld-promotion-breadcrumb" data={breadcrumbJsonLd} />
+      <section className="bg-[#FFF5F5]">
+        <div className="mx-auto max-w-5xl px-4 py-16 text-center">
+          <h1 className="text-4xl font-bold text-[#A70909] sm:text-5xl">{hero.title}</h1>
+          <p className="mt-6 text-lg text-gray-700 sm:text-xl">{hero.intro}</p>
+        </div>
+      </section>
+      <section className="mx-auto max-w-5xl px-4 space-y-10">
+        {offers.map((offer) => (
+          <article key={offer.name} className="rounded-3xl border border-[#A70909]/20 bg-white p-8 shadow-md">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+              <div className="space-y-4">
+                <h2 className="text-2xl font-semibold text-[#A70909]">{offer.name}</h2>
+                <ul className="space-y-3 text-base text-gray-700">
+                  {offer.bullets.map((bullet) => (
+                    <li key={bullet} className="flex items-start gap-3">
+                      <span className="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-[#A70909]" aria-hidden="true" />
+                      <span>{bullet}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div className="rounded-2xl bg-[#FFF0F0] p-6 text-left text-sm text-gray-600">
+                <p>{offer.note}</p>
+              </div>
+            </div>
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+              <a
+                href={`tel:${COMPANY.phone}`}
+                className="inline-flex min-w-[200px] items-center justify-center rounded-full border-2 border-[#A70909] px-6 py-3 text-sm font-semibold text-[#A70909] transition hover:bg-[#A70909] hover:text-white"
+              >
+                {cta}
+              </a>
+              <a
+                href={COMPANY.socials.line}
+                className="inline-flex min-w-[200px] items-center justify-center rounded-full bg-[#06C755] px-6 py-3 text-sm font-semibold text-white transition hover:brightness-110"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                LINE
+              </a>
+            </div>
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/app/[locale]/(pages)/under-construction/page.tsx
+++ b/app/[locale]/(pages)/under-construction/page.tsx
@@ -1,0 +1,138 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { COMPANY } from "@/data/company";
+import { absoluteUrl } from "@/config/site";
+import { buildLocaleAlternates } from "@/lib/metadata";
+import { JsonLd } from "@/components/common/JsonLd";
+import { loadMessages, resolveLocale } from "@/i18n/loadMessages";
+import { buildBreadcrumbJsonLd, buildFaqJsonLd, buildWebPageJsonLd } from "@/seo/jsonld";
+
+interface PageParams {
+  params: { locale: string };
+}
+
+export async function generateMetadata({ params }: PageParams): Promise<Metadata> {
+  const locale = resolveLocale(params.locale);
+  const messages = (await loadMessages(locale)) as any;
+  const meta = messages.metadata.resources as { title: string; description: string; keywords: string[] };
+  const path = `/${locale}/under-construction`;
+
+  return {
+    title: meta.title,
+    description: meta.description,
+    keywords: meta.keywords,
+    alternates: {
+      canonical: absoluteUrl(path),
+      languages: buildLocaleAlternates("/under-construction"),
+    },
+    openGraph: {
+      title: meta.title,
+      description: meta.description,
+      url: absoluteUrl(path),
+      siteName: COMPANY.brand,
+      type: "article",
+      locale,
+      images: [
+        {
+          url: absoluteUrl(`/${locale}/under-construction/opengraph-image`),
+          width: 1200,
+          height: 630,
+          alt: meta.title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: meta.title,
+      description: meta.description,
+      images: [absoluteUrl(`/${locale}/under-construction/opengraph-image`)],
+    },
+  };
+}
+
+export default async function ResourcesPage({ params }: PageParams) {
+  const { locale } = params;
+  const tResources = await getTranslations({ locale, namespace: "resources" });
+  const tBreadcrumbs = await getTranslations({ locale, namespace: "breadcrumbs" });
+
+  const hero = tResources.raw("hero") as { title: string; description: string };
+  const documents = tResources.raw("documents") as {
+    heading: string;
+    items: Array<{ title: string; description: string; actionLabel: string; actionHref: string }>;
+  };
+  const contact = tResources.raw("contact") as {
+    heading: string;
+    description: string;
+    channels: { phone: string; line: string; email: string };
+  };
+
+  const breadcrumbJsonLd = buildBreadcrumbJsonLd([
+    { name: tBreadcrumbs("home"), path: `/${locale}` },
+    { name: tBreadcrumbs("resources"), path: `/${locale}/under-construction` },
+  ]);
+  const webPageJsonLd = buildWebPageJsonLd({
+    locale,
+    title: hero.title,
+    description: hero.description,
+    path: `/${locale}/under-construction`,
+  });
+  const faqJsonLd = buildFaqJsonLd([
+    { question: contact.heading, answer: contact.description },
+  ]);
+
+  return (
+    <div className="space-y-16 pb-20">
+      <JsonLd id="jsonld-resources" data={webPageJsonLd} />
+      <JsonLd id="jsonld-resources-breadcrumb" data={breadcrumbJsonLd} />
+      <JsonLd id="jsonld-resources-faq" data={faqJsonLd} />
+      <section className="bg-[#FFFEFE]">
+        <div className="mx-auto max-w-5xl px-4 py-16 text-center">
+          <h1 className="text-4xl font-bold text-[#A70909] sm:text-5xl">{hero.title}</h1>
+          <p className="mt-6 text-lg text-gray-700 sm:text-xl">{hero.description}</p>
+        </div>
+      </section>
+      <section className="mx-auto max-w-5xl px-4">
+        <h2 className="text-2xl font-semibold text-[#A70909]">{documents.heading}</h2>
+        <div className="mt-6 grid gap-6 lg:grid-cols-3">
+          {documents.items.map((item) => (
+            <div key={item.title} className="flex h-full flex-col justify-between rounded-3xl border border-[#A70909]/15 bg-white p-6 shadow-sm">
+              <div className="space-y-4">
+                <h3 className="text-lg font-semibold text-[#A70909]">{item.title}</h3>
+                <p className="text-sm text-gray-600">{item.description}</p>
+              </div>
+              <a
+                href={item.actionHref}
+                className="mt-6 inline-flex items-center justify-center rounded-full border-2 border-[#A70909] px-5 py-2 text-sm font-semibold text-[#A70909] transition hover:bg-[#A70909] hover:text-white"
+                target={item.actionHref.startsWith("http") ? "_blank" : undefined}
+                rel={item.actionHref.startsWith("http") ? "noopener noreferrer" : undefined}
+              >
+                {item.actionLabel}
+              </a>
+            </div>
+          ))}
+        </div>
+      </section>
+      <section className="bg-[#FFECEC]">
+        <div className="mx-auto max-w-5xl px-4 py-16">
+          <div className="space-y-6 rounded-3xl bg-white/80 p-10 text-center shadow-lg">
+            <h2 className="text-3xl font-bold text-[#A70909] sm:text-4xl">{contact.heading}</h2>
+            <p className="mx-auto max-w-3xl text-base text-gray-700 sm:text-lg">{contact.description}</p>
+            <div className="flex flex-col gap-3 text-sm font-semibold text-[#A70909] sm:flex-row sm:justify-center">
+              <a href={`tel:${COMPANY.phone}`} className="hover:text-[#C9341F]">
+                {contact.channels.phone.replace('{phone}', COMPANY.phoneDisplay)}
+              </a>
+              <span className="hidden sm:inline">•</span>
+              <a href={COMPANY.socials.line} target="_blank" rel="noopener noreferrer" className="hover:text-[#C9341F]">
+                {contact.channels.line}
+              </a>
+              <span className="hidden sm:inline">•</span>
+              <a href={`mailto:${COMPANY.email}`} className="hover:text-[#C9341F]">
+                {contact.channels.email}
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/common/AnalyticsManager.tsx
+++ b/src/components/common/AnalyticsManager.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Script from "next/script";
+
+type Props = {
+  gaId?: string;
+  gtmId?: string;
+};
+
+const GA_ID = process.env.NEXT_PUBLIC_GA4_ID;
+const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID;
+
+export function AnalyticsManager({ gaId = GA_ID, gtmId = GTM_ID }: Props) {
+  if (!gaId && !gtmId) {
+    return null;
+  }
+
+  return (
+    <>
+      {gaId ? (
+        <>
+          <Script
+            src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+            strategy="afterInteractive"
+          />
+          <Script id="ga4-init" strategy="afterInteractive">
+            {`
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('consent', 'default', {
+                ad_storage: 'denied',
+                analytics_storage: 'denied',
+                functionality_storage: 'granted'
+              });
+              gtag('js', new Date());
+              gtag('config', '${gaId}', {
+                anonymize_ip: true,
+              });
+            `}
+          </Script>
+        </>
+      ) : null}
+      {gtmId ? (
+        <>
+          <Script id="gtm-init" strategy="afterInteractive">
+            {`
+              window.dataLayer = window.dataLayer || [];
+              window.dataLayer.push({
+                'gtm.start': new Date().getTime(),
+                event: 'gtm.js'
+              });
+            `}
+          </Script>
+          <noscript>
+            <iframe
+              src={`https://www.googletagmanager.com/ns.html?id=${gtmId}`}
+              height="0"
+              width="0"
+              style={{ display: "none", visibility: "hidden" }}
+              title="gtm"
+            />
+          </noscript>
+        </>
+      ) : null}
+    </>
+  );
+}

--- a/src/components/common/JsonLd.tsx
+++ b/src/components/common/JsonLd.tsx
@@ -1,0 +1,17 @@
+/* eslint-disable react/no-danger */
+import React from "react";
+
+type JsonLdProps = {
+  data: Record<string, unknown>;
+  id?: string;
+};
+
+export function JsonLd({ data, id }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      id={id}
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/src/i18n/loadMessages.ts
+++ b/src/i18n/loadMessages.ts
@@ -1,0 +1,15 @@
+import { i18n, type Locale } from "./config";
+
+export function resolveLocale(locale: string): Locale {
+  const normalized = locale?.toString() || i18n.defaultLocale;
+  const matched = i18n.locales.find(
+    (supported) => supported.toLowerCase() === normalized.toLowerCase(),
+  ) as Locale | undefined;
+
+  return matched ?? i18n.defaultLocale;
+}
+
+export async function loadMessages(locale: Locale | string) {
+  const resolved = resolveLocale(locale.toString());
+  return (await import(`../messages/${resolved}.json`)).default;
+}


### PR DESCRIPTION
## Summary
- add a shared locale resolver and reuse `loadMessages` for page metadata generation
- adjust metadata consumers and CTA translations to use the shared helper instead of inline dynamic imports
- tidy supporting utilities by keeping JSON-LD lint-safe and removing raw HTML injection from the analytics noscript tag

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc0eb9b458832b86a1e9c8edae5b40