### PR TITLE
Refine internationalisation and build tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,28 @@ NEXT_PUBLIC_GA4_ID=G-XXXXXXXXXX
 NEXT_PUBLIC_GTM_ID=GTM-XXXXXXX
 ```
 
-`NEXT_PUBLIC_SITE_URL` is used by metadata helpers and the sitemap generator to create absolute links. `NEXT_PUBLIC_GA4_ID` and `NEXT_PUBLIC_GTM_ID` enable Google Analytics 4 and Google Tag Manager via the `AnalyticsManager` component. Leave the analytics variables unset if you do not want the scripts to load.
+`NEXT_PUBLIC_SITE_URL` is used by metadata helpers and the sitemap generator to create absolute links. `NEXT_PUBLIC_GA4_ID` and `NEXT_PUBLIC_GTM_ID` enable Google Analytics 4 and Google Tag Manager via the consent-aware `AnalyticsManager` component. Leave the analytics variables unset if you do not want the scripts to load.
+
+## Supported locales
+
+The site is localised into the following locales (default locale **th**). Missing strings fall back to English and then Thai to avoid runtime holes:
+
+- `th`
+- `en`
+- `fr`
+- `de`
+- `nl`
+- `it`
+- `zh-Hant`
+- `zh-Hans`
+- `ja`
+- `ko`
+- `ms`
+- `ta`
+- `hi`
+- `ar`
+- `fa`
+- `he`
 
 ## Development
 
@@ -69,7 +90,7 @@ npm run postbuild
 
 ## Locale detection
 
-[`middleware.ts`](middleware.ts) uses `next-intl`'s middleware to inspect the `Accept-Language` header. Requests without a locale prefix are redirected to the best matching locale (or the default `th` locale when no match is found).
+[middleware.ts](middleware.ts) uses `next-intl` middleware to inspect the `Accept-Language` header. Requests without a locale prefix are redirected to `/${locale}` where `locale` is one of the supported locales above (falling back to `/th` when no match is found). All App Router routes live under `/[locale]/…` and the middleware keeps the prefix consistent for crawlers and sitemap generation.
 
 ## License
 

--- a/app/[locale]/(pages)/how-to/monthly-statements/page.tsx
+++ b/app/[locale]/(pages)/how-to/monthly-statements/page.tsx
@@ -64,17 +64,29 @@ export default async function MonthlyStatementsPage({ params }: PageParams) {
   const tBreadcrumbs = await getTranslations({ locale, namespace: 'breadcrumbs' });
   const tLayout = await getTranslations({ locale, namespace: 'layout' });
 
-  const hero = tHowTo.raw('monthlyStatements.hero') as {
-    title: string;
-    description: string;
+  const ensureString = (value: unknown): string =>
+    typeof value === 'string' ? value : value != null ? String(value) : '';
+
+  const heroRaw = (tHowTo.raw('monthlyStatements.hero') ?? {}) as Record<string, unknown>;
+  const hero = {
+    title: ensureString(heroRaw.title),
+    description: ensureString(heroRaw.description),
   };
-  const steps = tHowTo.raw('monthlyStatements.steps') as Array<{
-    title: string;
-    description: string;
-  }>;
-  const checklist = tHowTo.raw('monthlyStatements.checklist') as {
-    heading: string;
-    items: string[];
+  const stepsRaw = Array.isArray(tHowTo.raw('monthlyStatements.steps'))
+    ? (tHowTo.raw('monthlyStatements.steps') as Array<Record<string, unknown>>)
+    : [];
+  const steps = stepsRaw.map((step) => ({
+    title: ensureString(step.title),
+    description: ensureString(step.description),
+  }));
+  const checklistRaw = (tHowTo.raw('monthlyStatements.checklist') ?? {}) as Record<string, unknown>;
+  const checklist = {
+    heading: ensureString(checklistRaw.heading),
+    items: Array.isArray(checklistRaw.items)
+      ? (checklistRaw.items as unknown[])
+          .map((item) => ensureString(item))
+          .filter((item) => item.length > 0)
+      : [],
   };
   const chatLabel = tLayout('cta.chat');
 
@@ -139,7 +151,7 @@ export default async function MonthlyStatementsPage({ params }: PageParams) {
       <section className="mx-auto max-w-4xl px-4">
         <div className="rounded-3xl border border-[#A70909]/15 bg-white p-8 text-center shadow-sm">
           <p className="text-[clamp(0.95rem,0.9rem+0.3vw,1.1rem)] text-gray-700">
-            {tHowTo('monthlyStatements.cta').replace('{email}', COMPANY.email)}
+            {tHowTo('monthlyStatements.cta', { email: COMPANY.email })}
           </p>
           <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:justify-center">
             <a

--- a/app/[locale]/(pages)/services/bookkeeping/page.tsx
+++ b/app/[locale]/(pages)/services/bookkeeping/page.tsx
@@ -64,26 +64,51 @@ export default async function BookkeepingServicePage({ params }: PageParams) {
   const tServices = await getTranslations({ locale, namespace: 'services' });
   const tBreadcrumbs = await getTranslations({ locale, namespace: 'breadcrumbs' });
 
-  const hero = tServices.raw('bookkeeping.hero') as {
-    title: string;
-    subtitle: string;
-    description: string;
-    highlights: string[];
-    ctaCall: string;
-    ctaLine: string;
-    ctaEmail: string;
+  const ensureString = (value: unknown): string =>
+    typeof value === 'string' ? value : value != null ? String(value) : '';
+
+  const heroRaw = (tServices.raw('bookkeeping.hero') ?? {}) as Record<string, any>;
+  const hero = {
+    title: ensureString(heroRaw.title),
+    subtitle: ensureString(heroRaw.subtitle),
+    description: ensureString(heroRaw.description),
+    highlights: Array.isArray(heroRaw.highlights)
+      ? (heroRaw.highlights as unknown[])
+          .map((item) => ensureString(item))
+          .filter((item) => item.length > 0)
+      : [],
+    ctaCall: ensureString(heroRaw.ctaCall),
+    ctaLine: ensureString(heroRaw.ctaLine),
+    ctaEmail: ensureString(heroRaw.ctaEmail),
   };
-  const features = tServices.raw('bookkeeping.features') as {
-    heading: string;
-    items: Array<{ title: string; description: string }>;
+  const featuresRaw = (tServices.raw('bookkeeping.features') ?? {}) as Record<string, any>;
+  const features = {
+    heading: ensureString(featuresRaw.heading),
+    items: Array.isArray(featuresRaw.items)
+      ? (featuresRaw.items as Array<Record<string, unknown>>).map((item) => ({
+          title: ensureString(item?.title),
+          description: ensureString(item?.description),
+        }))
+      : [],
   };
-  const faq = tServices.raw('bookkeeping.faq') as {
-    heading: string;
-    items: Array<{ question: string; answer: string }>;
+  const faqRaw = (tServices.raw('bookkeeping.faq') ?? {}) as Record<string, any>;
+  const faq = {
+    heading: ensureString(faqRaw.heading),
+    items: Array.isArray(faqRaw.items)
+      ? (faqRaw.items as Array<Record<string, unknown>>).map((item) => ({
+          question: ensureString(item?.question),
+          answer: ensureString(item?.answer),
+        }))
+      : [],
   };
-  const deliverables = tServices.raw('bookkeeping.deliverables') as {
-    heading: string;
-    items: string[];
+  const deliverablesRaw = (tServices.raw('bookkeeping.deliverables') ?? {}) as Record<string, any>;
+  const deliverables = {
+    heading: ensureString(deliverablesRaw.heading),
+    items: Array.isArray(deliverablesRaw.items)
+      ? (deliverablesRaw.items as unknown[])
+          .map((item) => ensureString(item))
+          .filter((item) => item.length > 0)
+      : [],
   };
 
   const breadcrumbJsonLd = buildBreadcrumbJsonLd([

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,12 +1,12 @@
 import { notFound } from 'next/navigation';
-import { NextIntlClientProvider } from 'next-intl';
+import { NextIntlClientProvider, type AbstractIntlMessages } from 'next-intl';
 import { ReactNode } from 'react';
 import { unstable_setRequestLocale } from 'next-intl/server';
 import {
-  Cairo,
-  Heebo,
-  Hind,
   Inter,
+  Noto_Naskh_Arabic,
+  Noto_Sans_Devanagari,
+  Noto_Sans_Hebrew,
   Noto_Sans_JP,
   Noto_Sans_KR,
   Noto_Sans_SC,
@@ -16,31 +16,59 @@ import {
   Vazirmatn,
 } from 'next/font/google';
 import { i18n, type Locale } from '@/i18n/config';
-import { loadMessages, resolveLocale } from '@/i18n/loadMessages';
-import { Header, type HeaderData } from '@/components/layout/Header';
-import { Footer, type FooterData } from '@/components/layout/Footer';
+import { loadMessages, resolveLocale, type Messages } from '@/i18n/loadMessages';
+import {
+  Header,
+  type HeaderData,
+  type HeaderMegaMenuColumn,
+  type HeaderNavItem,
+} from '@/components/layout/Header';
+import { Footer, type FooterData, type FooterLink } from '@/components/layout/Footer';
 import { BusinessJsonLd } from '@/components/seo/BusinessJsonLd';
 import { AnalyticsManager } from '@/components/common/AnalyticsManager';
 
-const inter = Inter({ subsets: ['latin'], variable: '--font-latin' });
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
 const prompt = Prompt({
   subsets: ['thai'],
   weight: ['400', '500', '600', '700'],
-  variable: '--font-th',
+  variable: '--font-prompt',
 });
-const notoJP = Noto_Sans_JP({ subsets: ['latin'], variable: '--font-ja' });
-const notoKR = Noto_Sans_KR({ subsets: ['latin'], variable: '--font-ko' });
-const notoSC = Noto_Sans_SC({ subsets: ['latin'], variable: '--font-zhhans' });
-const notoTC = Noto_Sans_TC({ subsets: ['latin'], variable: '--font-zhhant' });
-const cairo = Cairo({ subsets: ['arabic'], variable: '--font-ar' });
-const vazir = Vazirmatn({ subsets: ['arabic'], variable: '--font-fa' });
-const heebo = Heebo({ subsets: ['hebrew'], variable: '--font-he' });
-const hind = Hind({
+const notoJP = Noto_Sans_JP({
   subsets: ['latin'],
-  weight: ['400', '500', '600', '700'],
-  variable: '--font-hi',
+  variable: '--font-noto-jp',
 });
-const notoTA = Noto_Sans_Tamil({ subsets: ['tamil'], variable: '--font-ta' });
+const notoKR = Noto_Sans_KR({
+  subsets: ['latin'],
+  variable: '--font-noto-kr',
+});
+const notoSC = Noto_Sans_SC({
+  subsets: ['latin'],
+  variable: '--font-noto-sc',
+});
+const notoTC = Noto_Sans_TC({
+  subsets: ['latin'],
+  variable: '--font-noto-tc',
+});
+const notoArabic = Noto_Naskh_Arabic({
+  subsets: ['arabic', 'latin'],
+  variable: '--font-noto-naskh',
+});
+const vazir = Vazirmatn({
+  subsets: ['arabic', 'latin'],
+  variable: '--font-vazirmatn',
+});
+const notoHebrew = Noto_Sans_Hebrew({
+  subsets: ['hebrew', 'latin'],
+  variable: '--font-noto-he',
+});
+const notoDevanagari = Noto_Sans_Devanagari({
+  subsets: ['devanagari', 'latin'],
+  variable: '--font-noto-devanagari',
+});
+const notoTA = Noto_Sans_Tamil({
+  subsets: ['tamil', 'latin'],
+  variable: '--font-noto-tamil',
+});
 
 const fontClassNames = [
   inter.variable,
@@ -49,12 +77,84 @@ const fontClassNames = [
   notoKR.variable,
   notoSC.variable,
   notoTC.variable,
-  cairo.variable,
+  notoArabic.variable,
   vazir.variable,
-  heebo.variable,
-  hind.variable,
+  notoHebrew.variable,
+  notoDevanagari.variable,
   notoTA.variable,
 ].join(' ');
+
+const RTL_LOCALES = new Set<Locale>(['ar', 'fa', 'he']);
+
+function ensureString(value: unknown, fallback = ''): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return fallback;
+}
+
+function sanitizeHeaderData(messages: Messages): HeaderData {
+  const raw = (messages.layout?.header ?? {}) as Record<string, unknown>;
+  const nav = Array.isArray(raw.nav) ? raw.nav : [];
+  const megaMenu = (raw.megaMenu ?? {}) as Record<string, unknown>;
+  const columns = Array.isArray(megaMenu.columns) ? megaMenu.columns : [];
+
+  return {
+    announcement: {
+      message: ensureString(
+        (raw.announcement as Record<string, unknown> | undefined)?.message,
+      ),
+      actionLabel: ensureString(
+        (raw.announcement as Record<string, unknown> | undefined)?.actionLabel,
+      ),
+      actionHref:
+        ensureString(
+          (raw.announcement as Record<string, unknown> | undefined)?.actionHref,
+        ) || '/',
+    },
+    nav: (nav as HeaderNavItem[]).map((item) => ({
+      label: ensureString(item?.label),
+      href: ensureString(item?.href, '#') || '#',
+    })),
+    megaMenu: {
+      triggerLabel: ensureString(megaMenu.triggerLabel),
+      columns: (columns as HeaderMegaMenuColumn[]).map((column) => ({
+        title: ensureString(column?.title),
+        items: Array.isArray(column?.items)
+          ? column.items.map((item) => ({
+              label: ensureString(item?.label),
+              description: ensureString(item?.description),
+              href: ensureString(item?.href, '#') || '#',
+            }))
+          : [],
+      })),
+    },
+    ctaPrimary: ensureString(raw.ctaPrimary),
+    ctaSecondary: ensureString(raw.ctaSecondary),
+  };
+}
+
+function sanitizeFooterData(messages: Messages): FooterData {
+  const raw = (messages.layout?.footer ?? {}) as Record<string, unknown>;
+  const contact = (raw.contact ?? {}) as Record<string, unknown>;
+  const quickLinks = Array.isArray(raw.quickLinks) ? raw.quickLinks : [];
+
+  return {
+    tagline: ensureString(raw.tagline),
+    description: ensureString(raw.description),
+    contact: {
+      phone: ensureString(contact.phone),
+      email: ensureString(contact.email),
+      line: ensureString(contact.line),
+    },
+    quickLinks: (quickLinks as FooterLink[]).map((link) => ({
+      label: ensureString(link?.label),
+      href: ensureString(link?.href, '#') || '#',
+    })),
+    legal: ensureString(raw.legal),
+  };
+}
 
 export async function generateStaticParams() {
   return i18n.locales.map((locale) => ({ locale }));
@@ -81,27 +181,24 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
   unstable_setRequestLocale(locale);
 
   const messages = await loadMessages(locale);
-  const header = (messages.layout?.header ?? {
-    announcement: { message: '', actionLabel: '', actionHref: '/' },
-    nav: [],
-    megaMenu: { triggerLabel: '', columns: [] },
-    ctaPrimary: '',
-    ctaSecondary: '',
-  }) as HeaderData;
-  const footer = (messages.layout?.footer ?? {
-    tagline: '',
-    description: '',
-    contact: { phone: '', email: '', line: '' },
-    quickLinks: [],
-    legal: '',
-  }) as FooterData;
+  const header = sanitizeHeaderData(messages);
+  const footer = sanitizeFooterData(messages);
+  const direction = RTL_LOCALES.has(locale) ? 'rtl' : 'ltr';
 
   return (
-    <html lang={locale} className={fontClassNames} suppressHydrationWarning>
+    <html
+      lang={locale}
+      dir={direction}
+      className={fontClassNames}
+      suppressHydrationWarning
+    >
       <body className="min-h-screen bg-[#FFFEFE] text-gray-900 antialiased">
-        <NextIntlClientProvider locale={locale} messages={messages}>
+        <NextIntlClientProvider
+          locale={locale}
+          messages={messages as unknown as AbstractIntlMessages}
+        >
           <AnalyticsManager />
-          <BusinessJsonLd />
+          <BusinessJsonLd locale={locale} />
           <div className="flex min-h-screen flex-col">
             <Header data={header} locale={locale} />
             <main className="flex-1">{children}</main>

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "eslint": "8.57.0",
         "eslint-config-next": "14.2.30",
         "jsdom": "^26.1.0",
+        "rimraf": "^6.0.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
       }
@@ -954,6 +955,29 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -4769,6 +4793,65 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/flat-cache/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/flat-cache/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/flat-cache/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/flat-cache/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/flatted": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
@@ -8165,62 +8248,106 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
-        "glob": "^7.1.3"
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
       },
       "bin": {
-        "rimraf": "bin.js"
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
+      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.0.3",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": "*"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
+    "node_modules/rimraf/node_modules/jackspeak": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "@isaacs/cliui": "^8.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/lru-cache": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rrweb-cssom": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "repo:dump:single": "node scripts/repo-dump.mjs --single --out reports/REPO-DUMP.md",
     "repo:dump:split": "node scripts/repo-dump.mjs --out reports --split",
     "repo:dump:all": "node scripts/repo-dump.mjs --single --out reports/REPO-ALL.md --include-dotfiles --include-env --include-binaries --b64-binaries",
-    "prebuild": "powershell -NoProfile -Command \"if (Test-Path .next) { Remove-Item .next -Recurse -Force }; if (Test-Path .turbo) { Remove-Item .turbo -Recurse -Force }\"",
-    "build:log": "powershell -NoProfile -Command \"npm run build *>&1 | Tee-Object build.log\""
+    "prebuild": "rimraf .next .turbo",
+    "build:log": "node scripts/build-with-log.cjs"
   },
   "dependencies": {
     "@testing-library/react": "^16.3.0",
@@ -41,6 +41,7 @@
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.30",
     "jsdom": "^26.1.0",
+    "rimraf": "^6.0.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   }

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-labelledby="virintira-logo-title">
+  <title id="virintira-logo-title">Virintira Logo</title>
+  <defs>
+    <linearGradient id="virintiraGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#A70909" />
+      <stop offset="100%" stop-color="#D63C1F" />
+    </linearGradient>
+  </defs>
+  <rect width="120" height="120" rx="28" fill="url(#virintiraGradient)" />
+  <path
+    d="M34 86L58 34h12l24 52h-13l-17-38-17 38H34zm44-52l-7.2 16.4 7.2 15.8h12L76 48h12l6 13.2L98 34H78z"
+    fill="#fff"
+  />
+</svg>

--- a/scripts/build-with-log.cjs
+++ b/scripts/build-with-log.cjs
@@ -1,0 +1,27 @@
+const { spawn } = require('node:child_process');
+const { createWriteStream } = require('node:fs');
+const path = require('node:path');
+
+const logPath = path.join(process.cwd(), 'build.log');
+const logStream = createWriteStream(logPath);
+
+const child = spawn('npm', ['run', 'build'], {
+  shell: process.platform === 'win32',
+  stdio: ['inherit', 'pipe', 'pipe'],
+});
+
+function relay(stream, destination) {
+  stream.on('data', (chunk) => {
+    destination.write(chunk);
+    logStream.write(chunk);
+  });
+}
+
+relay(child.stdout, process.stdout);
+relay(child.stderr, process.stderr);
+
+child.on('close', (code) => {
+  logStream.end(() => {
+    process.exit(code ?? 0);
+  });
+});

--- a/src/components/common/AnalyticsManager.tsx
+++ b/src/components/common/AnalyticsManager.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Script from "next/script";
 
 type Props = {
@@ -7,60 +8,112 @@ type Props = {
   gtmId?: string;
 };
 
+type ConsentState = "checking" | "pending" | "granted" | "denied";
+
 const GA_ID = process.env.NEXT_PUBLIC_GA4_ID;
 const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID;
+const STORAGE_KEY = "virintira-analytics-consent";
 
 export function AnalyticsManager({ gaId = GA_ID, gtmId = GTM_ID }: Props) {
+  const [consent, setConsent] = useState<ConsentState>("checking");
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored === "granted" || stored === "denied") {
+      setConsent(stored);
+    } else {
+      setConsent("pending");
+    }
+  }, []);
+
   if (!gaId && !gtmId) {
     return null;
   }
 
+  const shouldLoad = consent === "granted";
+
+  const handleConsent = (value: Extract<ConsentState, "granted" | "denied">) => () => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, value);
+    }
+    setConsent(value);
+  };
+
   return (
     <>
-      {gaId ? (
+      {shouldLoad && (
         <>
-          <Script
-            src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
-            strategy="afterInteractive"
-          />
-          <Script id="ga4-init" strategy="afterInteractive">
-            {`
-              window.dataLayer = window.dataLayer || [];
-              function gtag(){dataLayer.push(arguments);}
-              gtag('consent', 'default', {
-                ad_storage: 'denied',
-                analytics_storage: 'denied',
-                functionality_storage: 'granted'
-              });
-              gtag('js', new Date());
-              gtag('config', '${gaId}', {
-                anonymize_ip: true,
-              });
-            `}
-          </Script>
+          {gaId ? (
+            <>
+              <Script
+                src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+                strategy="afterInteractive"
+              />
+              <Script id="ga4-init" strategy="afterInteractive">
+                {`
+                  window.dataLayer = window.dataLayer || [];
+                  function gtag(){dataLayer.push(arguments);}
+                  gtag('js', new Date());
+                  gtag('consent', 'update', {
+                    ad_storage: 'granted',
+                    analytics_storage: 'granted',
+                    functionality_storage: 'granted'
+                  });
+                  gtag('config', '${gaId}', {
+                    anonymize_ip: true,
+                  });
+                `}
+              </Script>
+            </>
+          ) : null}
+          {gtmId ? (
+            <>
+              <Script id="gtm-init" strategy="afterInteractive">
+                {`
+                  window.dataLayer = window.dataLayer || [];
+                  window.dataLayer.push({
+                    'gtm.start': new Date().getTime(),
+                    event: 'gtm.js'
+                  });
+                `}
+              </Script>
+              <noscript>
+                <iframe
+                  src={`https://www.googletagmanager.com/ns.html?id=${gtmId}`}
+                  height="0"
+                  width="0"
+                  style={{ display: "none", visibility: "hidden" }}
+                  title="gtm"
+                />
+              </noscript>
+            </>
+          ) : null}
         </>
-      ) : null}
-      {gtmId ? (
-        <>
-          <Script id="gtm-init" strategy="afterInteractive">
-            {`
-              window.dataLayer = window.dataLayer || [];
-              window.dataLayer.push({
-                'gtm.start': new Date().getTime(),
-                event: 'gtm.js'
-              });
-            `}
-          </Script>
-          <noscript>
-            <iframe
-              src={`https://www.googletagmanager.com/ns.html?id=${gtmId}`}
-              height="0"
-              width="0"
-              style={{ display: "none", visibility: "hidden" }}
-              title="gtm"
-            />
-          </noscript>
-        </>
+      )}
+
+      {(gaId || gtmId) && consent === "pending" ? (
+        <div className="fixed bottom-4 left-4 right-4 z-50 mx-auto w-full max-w-xl rounded-2xl border border-[#A70909]/20 bg-white p-4 shadow-xl">
+          <p className="text-sm text-gray-800">
+            We use cookies to understand site traffic and deliver tailored campaigns. Allow analytics and tag manager scripts?
+          </p>
+          <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={handleConsent("denied")}
+              className="inline-flex items-center justify-center rounded-full border border-[#A70909]/30 px-4 py-2 text-sm font-semibold text-[#A70909] transition hover:bg-[#A70909]/10"
+            >
+              Decline
+            </button>
+            <button
+              type="button"
+              onClick={handleConsent("granted")}
+              className="inline-flex items-center justify-center rounded-full bg-[#A70909] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#C9341F]"
+            >
+              Allow
+            </button>
+          </div>
+        </div>
       ) : null}
     </>
   );

--- a/src/components/seo/BusinessJsonLd.tsx
+++ b/src/components/seo/BusinessJsonLd.tsx
@@ -2,16 +2,28 @@ import { COMPANY } from '@/data/company';
 import { JsonLd } from '@/components/common/JsonLd';
 import { absoluteUrl } from '@/config/site';
 
-export function BusinessJsonLd() {
+type Props = {
+  locale: string;
+};
+
+const MAP_URL = `https://www.google.com/maps/search/?api=1&query=${COMPANY.address.latitude},${COMPANY.address.longitude}`;
+
+export function BusinessJsonLd({ locale }: Props) {
+  const localizedUrl = absoluteUrl(`/${locale}`);
+
   const data = {
     '@context': 'https://schema.org',
     '@type': ['Organization', 'LocalBusiness'],
+    '@id': `${localizedUrl}#organization`,
     name: COMPANY.legalNameTh,
     legalName: COMPANY.legalNameTh,
     alternateName: COMPANY.legalNameEn,
-    url: absoluteUrl('/'),
+    url: localizedUrl,
+    logo: absoluteUrl('/logo.svg'),
+    image: absoluteUrl('/logo.svg'),
     email: COMPANY.email,
     telephone: COMPANY.phone,
+    priceRange: '฿฿',
     sameAs: [
       COMPANY.socials.facebook,
       COMPANY.socials.line,
@@ -31,13 +43,14 @@ export function BusinessJsonLd() {
       longitude: COMPANY.address.longitude,
     },
     areaServed: COMPANY.areaServed.map((name) => ({ '@type': 'Country', name })),
+    hasMap: MAP_URL,
     openingHoursSpecification: COMPANY.businessHours.map((hours) => ({
       '@type': 'OpeningHoursSpecification',
       dayOfWeek: hours.dayOfWeek,
       opens: hours.opens,
       closes: hours.closes,
     })),
-  };
+  } as const;
 
   return <JsonLd id="business-jsonld" data={data} />;
 }

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,9 +1,18 @@
+import type { AbstractIntlMessages } from 'next-intl';
+import { getRequestConfig } from 'next-intl/server';
 import { i18n } from './config';
+import { loadMessages, resolveLocale } from './loadMessages';
 
-export default function getRequestConfig() {
+export default getRequestConfig(async ({ requestLocale }) => {
+  const candidate = (await requestLocale) ?? i18n.defaultLocale;
+  const resolved = resolveLocale(candidate);
+  const messages = await loadMessages(resolved);
+
   return {
-    locales: i18n.locales,
+    locale: resolved,
+    messages: messages as unknown as AbstractIntlMessages,
     defaultLocale: i18n.defaultLocale,
+    locales: i18n.locales,
     localePrefix: 'always' as const,
   };
-}
+});

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,52 +2,101 @@
 @tailwind components;
 @tailwind utilities;
 
-html {
-  font-family: var(--font-latin), system-ui, -apple-system, 'Segoe UI', Arial, sans-serif;
+:root {
+  --font-size-body: clamp(0.95rem, 0.88rem + 0.35vw, 1.1rem);
+  --font-size-small: clamp(0.85rem, 0.8rem + 0.25vw, 0.95rem);
+  --font-size-h1: clamp(2.25rem, 1.5rem + 2.4vw, 3.5rem);
+  --font-size-h2: clamp(1.85rem, 1.3rem + 1.6vw, 2.6rem);
+  --font-size-h3: clamp(1.35rem, 1.1rem + 0.8vw, 1.85rem);
 }
 
-html[lang="th"] {
-  font-family: var(--font-th), var(--font-latin), sans-serif;
+body {
+  font-family: var(--font-inter), system-ui, -apple-system, 'Segoe UI', Arial, sans-serif;
+  font-size: var(--font-size-body);
+  line-height: 1.65;
+  background-color: #fffefe;
+  color: #1f1f1f;
 }
 
-html[lang="ja"] {
-  font-family: var(--font-ja), var(--font-latin), sans-serif;
+p,
+li {
+  font-size: var(--font-size-body);
 }
 
-html[lang="ko"] {
-  font-family: var(--font-ko), var(--font-latin), sans-serif;
+small,
+.text-xs {
+  font-size: var(--font-size-small);
 }
 
-html[lang="zh-Hans"] {
-  font-family: var(--font-zhhans), var(--font-latin), sans-serif;
+h1,
+.text-h1 {
+  font-size: var(--font-size-h1);
+  line-height: 1.1;
 }
 
-html[lang="zh-Hant"] {
-  font-family: var(--font-zhhant), var(--font-latin), sans-serif;
+h2,
+.text-h2 {
+  font-size: var(--font-size-h2);
+  line-height: 1.2;
 }
 
-html[lang="ar"] {
-  font-family: var(--font-ar), var(--font-latin), sans-serif;
+h3,
+.text-h3 {
+  font-size: var(--font-size-h3);
+  line-height: 1.3;
 }
 
-html[lang="fa"] {
-  font-family: var(--font-fa), var(--font-latin), sans-serif;
+:lang(th) {
+  font-family: var(--font-prompt), system-ui, sans-serif;
 }
 
-html[lang="he"] {
-  font-family: var(--font-he), var(--font-latin), sans-serif;
+:lang(en),
+:lang(fr),
+:lang(de),
+:lang(nl),
+:lang(it),
+:lang(ms) {
+  font-family: var(--font-inter), system-ui, sans-serif;
 }
 
-html[lang="hi"] {
-  font-family: var(--font-hi), var(--font-latin), sans-serif;
+:lang(zh-Hans) {
+  font-family: var(--font-noto-sc), system-ui, sans-serif;
 }
 
-html[lang="ta"] {
-  font-family: var(--font-ta), var(--font-latin), sans-serif;
+:lang(zh-Hant) {
+  font-family: var(--font-noto-tc), system-ui, sans-serif;
 }
 
-html[lang="ar"],
-html[lang="fa"],
-html[lang="he"] {
+:lang(ja) {
+  font-family: var(--font-noto-jp), system-ui, sans-serif;
+}
+
+:lang(ko) {
+  font-family: var(--font-noto-kr), system-ui, sans-serif;
+}
+
+:lang(ar) {
+  font-family: var(--font-noto-naskh), system-ui, serif;
+}
+
+:lang(fa) {
+  font-family: var(--font-vazirmatn), system-ui, sans-serif;
+}
+
+:lang(he) {
+  font-family: var(--font-noto-he), system-ui, sans-serif;
+}
+
+:lang(hi) {
+  font-family: var(--font-noto-devanagari), system-ui, sans-serif;
+}
+
+:lang(ta) {
+  font-family: var(--font-noto-tamil), system-ui, sans-serif;
+}
+
+:lang(ar),
+:lang(fa),
+:lang(he) {
   direction: rtl;
 }


### PR DESCRIPTION
## Summary
- replace the PowerShell prebuild command with rimraf and add a cross-platform build logging script
- harden next-intl by merging locale fallbacks, updating the locale layout with language specific fonts/JSON-LD, and adding consent-aware analytics
- guard content driven pages against missing data, update styling, ship an SVG logo, and document the supported locale matrix

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd03f463f0832b99186d5c83119f34