### PR TITLE
Align navbar menus with legacy styling

### DIFF
--- a/src/components/navbar/MegaMenu.tsx
+++ b/src/components/navbar/MegaMenu.tsx
@@ -1,52 +1,63 @@
+"use client";
+
 import { COMPANY } from '@/data/company';
 import { Link } from '@/i18n/routing';
+import { isExternalHref, normalizeInternalHref } from '@/lib/links';
 
 import type { MegaMenuColumn } from './types';
 
-function isExternal(href: string) {
-  return /^(https?:|mailto:|tel:)/.test(href);
-}
-
-function resolveHref(href: string) {
-  if (!href) return '#';
-  if (href.startsWith('#')) return href;
-  if (isExternal(href)) return href;
-  return href.startsWith('/') ? href : `/${href}`;
-}
-
-export function MegaMenu({ columns }: { columns: MegaMenuColumn[] }) {
+export function MegaMenu({
+  columns,
+  onMouseEnter,
+  onMouseLeave,
+  onLinkClick,
+}: {
+  columns: MegaMenuColumn[];
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+  onLinkClick?: () => void;
+}) {
   return (
-    <div className="absolute left-1/2 top-full z-30 mt-4 w-[640px] -translate-x-1/2 rounded-[32px] border border-virintira-border bg-white p-8 text-left shadow-2xl shadow-black/10">
-      <div className="grid gap-8 sm:grid-cols-2">
+    <div
+      className="fixed left-0 top-[var(--header-height,72px)] z-40 w-full border-t border-gray-200 bg-white shadow-md"
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      <div className="mx-auto grid max-w-7xl grid-cols-1 gap-6 px-8 py-6 text-sm sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
         {columns.map((column) => (
-          <div key={column.title} className="space-y-4">
-            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-virintira-muted">
-              {column.title}
-            </p>
-            <ul className="space-y-3">
+          <div key={column.title} className="space-y-3">
+            <h4 className="text-base font-semibold text-[#A70909]">{column.title}</h4>
+            <ul className="space-y-2">
               {column.items.map((item) => {
-                const href = resolveHref(item.href);
-                const content = (
-                  <div className="rounded-2xl border border-transparent p-4 transition hover:border-virintira-primary/30 hover:bg-virintira-soft">
-                    <p className="font-semibold text-virintira-primary">{item.label}</p>
-                    {item.description ? (
-                      <p className="mt-1 text-sm text-virintira-muted">{item.description}</p>
-                    ) : null}
-                  </div>
-                );
+                const href = item.href;
+                const isAnchor = href.startsWith('#');
+                const isExternal = isExternalHref(href);
+                const label = item.label;
 
-                if (href.startsWith('#') || isExternal(href)) {
+                if (isAnchor || isExternal) {
                   return (
-                    <li key={item.label}>
-                      <a href={href}>{content}</a>
+                    <li key={label}>
+                      <a
+                        href={href}
+                        onClick={onLinkClick}
+                        className="block text-gray-700 transition hover:text-[#A70909]"
+                      >
+                        {label}
+                      </a>
                     </li>
                   );
                 }
 
+                const normalized = normalizeInternalHref(href);
                 return (
-                  <li key={item.label}>
-                    <Link href={href} prefetch>
-                      {content}
+                  <li key={label}>
+                    <Link
+                      href={normalized}
+                      onClick={onLinkClick}
+                      className="block text-gray-700 transition hover:text-[#A70909]"
+                      prefetch
+                    >
+                      {label}
                     </Link>
                   </li>
                 );
@@ -55,11 +66,11 @@ export function MegaMenu({ columns }: { columns: MegaMenuColumn[] }) {
           </div>
         ))}
       </div>
-      <div className="mt-8 flex items-center justify-between rounded-2xl bg-virintira-soft px-6 py-4 text-sm text-virintira-muted">
-        <span>{COMPANY.legalNameTh}</span>
-        <a className="font-semibold text-virintira-primary" href={`tel:${COMPANY.phone}`}>
-          {COMPANY.phoneDisplay}
-        </a>
+      <div className="border-t border-gray-200 bg-white/90">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-8 py-4 text-xs text-gray-600">
+          <span>{COMPANY.legalNameTh}</span>
+          <span>{COMPANY.phoneDisplay}</span>
+        </div>
       </div>
     </div>
   );

--- a/src/components/navbar/MobileMenuView.tsx
+++ b/src/components/navbar/MobileMenuView.tsx
@@ -1,126 +1,133 @@
 "use client";
 
-import { COMPANY } from '@/data/company';
+import { useEffect, useState } from 'react';
+
 import { Link } from '@/i18n/routing';
+import { isExternalHref, normalizeInternalHref } from '@/lib/links';
 
-import type { MegaMenuColumn, NavItem } from './types';
-import { LanguageSwitcher } from './LanguageSwitcher';
-import { BackButton } from './BackButton';
+export type MobileMenuEntry = {
+  label: string;
+  href?: string;
+  items?: MobileMenuEntry[];
+};
 
-function isExternal(href: string) {
-  return /^(https?:|mailto:|tel:)/.test(href);
-}
-
-function resolveHref(href: string) {
-  if (!href) return '#';
-  if (href.startsWith('#')) return href;
-  if (isExternal(href)) return href;
-  return href.startsWith('/') ? href : `/${href}`;
-}
+type MobileMenuViewProps = {
+  title: string;
+  items: MobileMenuEntry[];
+  onBack?: () => void;
+  onSelectSubMenu?: (items: MobileMenuEntry[], title: string) => void;
+  onClose: () => void;
+  index: number;
+  current: number;
+};
 
 export function MobileMenuView({
-  nav,
-  columns,
+  title,
+  items,
+  onBack,
+  onSelectSubMenu,
   onClose,
-  ctaPrimary,
-  ctaSecondary,
-}: {
-  nav: NavItem[];
-  columns: MegaMenuColumn[];
-  onClose: () => void;
-  ctaPrimary: string;
-  ctaSecondary: string;
-}) {
+  index,
+  current,
+}: MobileMenuViewProps) {
+  const [isActive, setIsActive] = useState(false);
+
+  useEffect(() => {
+    if (index === current) {
+      requestAnimationFrame(() => setIsActive(true));
+    } else {
+      setIsActive(false);
+    }
+  }, [current, index]);
+
+  const translate = isActive ? 0 : 100;
+
   return (
-    <div className="flex h-full flex-col gap-6 overflow-y-auto bg-white p-6">
-      <div className="flex items-center justify-between">
-        <BackButton onClick={onClose} label="Close" />
-        <LanguageSwitcher variant="pill" />
-      </div>
-      <nav className="space-y-3" aria-label="Primary">
-        {nav.map((item) => {
-          const href = resolveHref(item.href);
-          if (href.startsWith('#') || isExternal(href)) {
-            return (
-              <a
-                key={item.label}
-                href={href}
-                className="block rounded-2xl border border-transparent bg-virintira-soft px-4 py-3 text-lg font-semibold text-virintira-primary transition hover:border-virintira-primary/50 hover:bg-white"
-                onClick={onClose}
-              >
-                {item.label}
-              </a>
-            );
-          }
-          return (
-            <Link
-              key={item.label}
-              href={href}
-              className="block rounded-2xl border border-transparent bg-virintira-soft px-4 py-3 text-lg font-semibold text-virintira-primary transition hover:border-virintira-primary/50 hover:bg-white"
-              onClick={onClose}
-              prefetch
+    <div
+      className="absolute inset-0 h-full w-full transform transition-transform duration-500 ease-in-out"
+      style={{ transform: `translateX(${translate}%)` }}
+    >
+      <div className="flex h-full w-full flex-col bg-white p-6">
+        <div className="mb-4 flex items-center justify-between">
+          {onBack ? (
+            <button
+              type="button"
+              onClick={onBack}
+              className="text-lg font-semibold text-[#A70909]"
             >
-              {item.label}
-            </Link>
-          );
-        })}
-      </nav>
-      <div className="space-y-6">
-        {columns.map((column) => (
-          <section key={column.title} className="space-y-3">
-            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-virintira-muted">
-              {column.title}
-            </p>
-            <div className="space-y-3">
-              {column.items.map((item) => {
-                const href = resolveHref(item.href);
-                const card = (
-                  <div className="rounded-2xl border border-virintira-border bg-white p-4 shadow-sm transition hover:border-virintira-primary/40 hover:shadow-lg">
-                    <p className="font-semibold text-virintira-primary">{item.label}</p>
-                    {item.description ? (
-                      <p className="mt-1 text-sm text-virintira-muted">{item.description}</p>
-                    ) : null}
-                  </div>
-                );
+              ←
+            </button>
+          ) : (
+            <span className="w-4" />
+          )}
+          <h2 className="text-lg font-semibold text-[#A70909]">{title}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-2xl font-bold text-[#A70909]"
+            aria-label="Close menu"
+          >
+            ✕
+          </button>
+        </div>
+        <ul className="space-y-4" role="menu" aria-label={title}>
+          {items.map((item) => {
+            if (item.items?.length) {
+              return (
+                <li key={item.label}>
+                  <button
+                    type="button"
+                    onClick={() => onSelectSubMenu?.(item.items ?? [], item.label)}
+                    className="w-full text-left text-base font-medium text-black transition hover:text-[#A70909]"
+                  >
+                    {item.label}
+                  </button>
+                </li>
+              );
+            }
 
-                if (href.startsWith('#') || isExternal(href)) {
-                  return (
-                    <a key={item.label} href={href} onClick={onClose}>
-                      {card}
-                    </a>
+            const href = item.href ?? '#';
+            const label =
+              item.label.includes('โปรโมชั่น') && !item.label.includes('🔥')
+                ? (
+                    <>
+                      {item.label}{' '}
+                      <span className="inline-block animate-bounce">🔥</span>
+                    </>
+                  )
+                : (
+                    item.label
                   );
-                }
 
-                return (
-                  <Link key={item.label} href={href} onClick={onClose} prefetch>
-                    {card}
-                  </Link>
-                );
-              })}
-            </div>
-          </section>
-        ))}
-      </div>
-      <div className="space-y-3">
-        <a
-          href={`tel:${COMPANY.phone}`}
-          className="block w-full rounded-full bg-virintira-primary px-4 py-3 text-center text-sm font-semibold text-white shadow transition hover:bg-virintira-primary-dark"
-        >
-          {ctaPrimary}
-        </a>
-        <a
-          href={COMPANY.socials.line}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="block w-full rounded-full border border-[#06C755] bg-[#06C755] px-4 py-3 text-center text-sm font-semibold text-white shadow transition hover:brightness-110"
-        >
-          {ctaSecondary}
-        </a>
-      </div>
-      <div className="space-y-1 text-xs text-virintira-muted">
-        <p>{COMPANY.legalNameTh}</p>
-        <p>{COMPANY.legalNameEn}</p>
-        <p>{COMPANY.phoneDisplay}</p>
+            if (href.startsWith('#') || isExternalHref(href)) {
+              return (
+                <li key={item.label}>
+                  <a
+                    href={href}
+                    onClick={onClose}
+                    className="block text-base font-medium text-black transition hover:text-[#A70909]"
+                  >
+                    {label}
+                  </a>
+                </li>
+              );
+            }
+
+            const normalized = normalizeInternalHref(href);
+            return (
+              <li key={item.label}>
+                <Link
+                  href={normalized}
+                  onClick={onClose}
+                  className="block text-base font-medium text-black transition hover:text-[#A70909]"
+                  prefetch
+                >
+                  {label}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
       </div>
     </div>
   );

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -1,9 +1,19 @@
 "use client";
 
-import { useState } from 'react';
+import Image from 'next/image';
+import { useLocale } from 'next-intl';
+import {
+  type MouseEvent,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import { COMPANY } from '@/data/company';
-import { Link } from '@/i18n/routing';
+import { Link, usePathname } from '@/i18n/routing';
+import { isExternalHref, normalizeInternalHref } from '@/lib/links';
 
 import { HamburgerButton } from './HamburgerButton';
 import { LanguageSwitcher } from './LanguageSwitcher';
@@ -13,125 +23,216 @@ import { SearchToggle } from './SearchToggle';
 import { SocialFloating } from './SocialFloating';
 import type { NavbarData } from './types';
 
-function isExternal(href: string) {
-  return /^(https?:|mailto:|tel:)/.test(href);
-}
-
-function resolveHref(href: string) {
-  if (!href) return '#';
-  if (href.startsWith('#')) return href;
-  if (isExternal(href)) return href;
-  return href.startsWith('/') ? href : `/${href}`;
-}
+const DEFAULT_HEADER_HEIGHT = 72;
+const HIDE_DELAY = 150;
 
 export function Navbar({ data }: { data: NavbarData }) {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
+  const [isHoveringMenu, setIsHoveringMenu] = useState(false);
+  const hideTimer = useRef<NodeJS.Timeout | null>(null);
+  const headerRef = useRef<HTMLElement | null>(null);
+  const pathname = usePathname();
+  const locale = useLocale();
 
-  const announcementHref = data.announcement?.actionHref
-    ? resolveHref(data.announcement.actionHref)
-    : '#';
-  const announcementIsExternal = data.announcement?.actionHref
-    ? isExternal(data.announcement.actionHref)
-    : false;
+  const handleOpenMegaMenu = useCallback(() => {
+    if (hideTimer.current) clearTimeout(hideTimer.current);
+    setIsHoveringMenu(true);
+  }, []);
+
+  const handleCloseMegaMenu = useCallback(() => {
+    if (hideTimer.current) clearTimeout(hideTimer.current);
+    hideTimer.current = setTimeout(() => {
+      setIsHoveringMenu(false);
+    }, HIDE_DELAY);
+  }, []);
+
+  const cancelCloseMegaMenu = useCallback(() => {
+    if (hideTimer.current) {
+      clearTimeout(hideTimer.current);
+      hideTimer.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (hideTimer.current) {
+        clearTimeout(hideTimer.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    setIsHoveringMenu(false);
+  }, [pathname]);
+
+  useLayoutEffect(() => {
+    const updateHeight = () => {
+      const header = headerRef.current;
+      if (!header) return;
+      const height = header.offsetHeight;
+      const root = document.documentElement;
+      const current = parseFloat(
+        getComputedStyle(root).getPropertyValue('--header-height') || '0',
+      );
+
+      if (height && height !== current) {
+        root.style.setProperty('--header-height', `${height}px`);
+      } else if (!current) {
+        root.style.setProperty('--header-height', `${DEFAULT_HEADER_HEIGHT}px`);
+      }
+    };
+
+    updateHeight();
+    window.addEventListener('resize', updateHeight);
+    return () => {
+      window.removeEventListener('resize', updateHeight);
+    };
+  }, []);
+
+  const handleLogoClick = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>) => {
+      const normalizedPath = pathname.endsWith('/') && pathname.length > 1 ? pathname.slice(0, -1) : pathname;
+      const homePaths = new Set(['/', `/${locale}`, '']);
+      if (homePaths.has(normalizedPath)) {
+        event.preventDefault();
+        const target = document.getElementById('herosection');
+        if (target) {
+          target.scrollIntoView({ behavior: 'smooth' });
+        } else {
+          window.scrollTo({ top: 0, behavior: 'smooth' });
+        }
+      }
+    },
+    [locale, pathname],
+  );
 
   return (
     <>
       <SocialFloating />
-      <header className="sticky top-0 z-50 w-full bg-white/95 text-virintira-primary shadow backdrop-blur">
+      <header
+        ref={headerRef}
+        className="fixed left-0 top-0 z-50 w-full bg-[#FFFEFE] shadow-sm"
+      >
         {data.announcement?.message ? (
           <div className="bg-virintira-primary text-white">
-            <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-4 py-2 text-sm">
+            <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-4 px-4 py-2 text-sm">
               <p className="font-medium">{data.announcement.message}</p>
               {data.announcement.actionLabel ? (
-                announcementHref.startsWith('#') || announcementIsExternal ? (
-                  <a
-                    href={announcementHref}
-                    className="inline-flex items-center gap-2 rounded-full border border-white/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:bg-white hover:text-virintira-primary"
-                  >
-                    {data.announcement.actionLabel}
-                  </a>
-                ) : (
-                  <Link
-                    href={announcementHref}
-                    className="inline-flex items-center gap-2 rounded-full border border-white/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:bg-white hover:text-virintira-primary"
-                    prefetch
-                  >
-                    {data.announcement.actionLabel}
-                  </Link>
-                )
+                (() => {
+                  const href = data.announcement?.actionHref;
+                  if (!href) return null;
+                  if (href.startsWith('#') || isExternalHref(href)) {
+                    return (
+                      <a
+                        href={href}
+                        className="inline-flex items-center gap-2 rounded-full border border-white/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:bg-white hover:text-virintira-primary"
+                      >
+                        {data.announcement.actionLabel}
+                      </a>
+                    );
+                  }
+                  const normalized = normalizeInternalHref(href);
+                  return (
+                    <Link
+                      href={normalized}
+                      className="inline-flex items-center gap-2 rounded-full border border-white/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:bg-white hover:text-virintira-primary"
+                      prefetch
+                    >
+                      {data.announcement.actionLabel}
+                    </Link>
+                  );
+                })()
               ) : null}
             </div>
           </div>
         ) : null}
-        <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-5">
-          <div className="flex items-center gap-6">
-            <Link href="/" className="flex items-center gap-3" prefetch>
-              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-virintira-primary/10 text-2xl font-bold">
-                VT
-              </div>
-              <div className="space-y-0.5">
-                <span className="block text-base font-extrabold leading-tight">
-                  {COMPANY.legalNameTh}
-                </span>
-                <span className="block text-xs text-virintira-muted">
-                  {COMPANY.legalNameEn}
-                </span>
-              </div>
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-5">
+          <div className="flex items-center gap-8">
+            <Link
+              href="/"
+              className="flex items-center gap-3"
+              onClick={handleLogoClick}
+              prefetch
+            >
+              <Image
+                src="/logo.png"
+                alt={COMPANY.legalNameEn}
+                width={40}
+                height={40}
+                priority
+              />
+              <span className="text-xl font-bold text-[#A70909] uppercase tracking-[0.2em]">
+                VIRINTIRA
+              </span>
             </Link>
-            <nav aria-label="Primary" className="hidden items-center gap-2 xl:flex">
+            <nav className="hidden items-center gap-6 lg:flex" aria-label="Primary">
               {data.nav.map((item) => {
-                const href = resolveHref(item.href);
-                const className =
-                  'rounded-full px-4 py-2 text-sm font-semibold text-virintira-primary transition hover:bg-virintira-primary/10';
-                if (href.startsWith('#') || isExternal(href)) {
+                const href = item.href;
+                const isExternal = isExternalHref(href);
+                const isAnchor = href.startsWith('#');
+                const content = (
+                  <span className="relative font-medium text-black transition hover:text-[#A70909] after:absolute after:-bottom-6 after:left-0 after:h-[7px] after:w-full after:rounded-t-full after:bg-[#A70909] after:origin-center after:scale-x-0 after:transition-transform hover:after:scale-x-[1.2]">
+                    {item.label}
+                  </span>
+                );
+
+                if (isExternal || isAnchor) {
                   return (
-                    <a key={item.label} href={href} className={className}>
-                      {item.label}
+                    <a key={item.label} href={href} className="inline-flex items-center">
+                      {content}
                     </a>
                   );
                 }
+
+                const normalized = normalizeInternalHref(href);
                 return (
-                  <Link key={item.label} href={href} className={className} prefetch>
-                    {item.label}
+                  <Link key={item.label} href={normalized} className="inline-flex items-center" prefetch>
+                    {content}
                   </Link>
                 );
               })}
               {data.megaMenu.columns.length ? (
-                <div className="group relative">
+                <div
+                  className="relative"
+                  onMouseEnter={handleOpenMegaMenu}
+                  onMouseLeave={handleCloseMegaMenu}
+                  onFocus={cancelCloseMegaMenu}
+                  onBlur={handleCloseMegaMenu}
+                >
                   <button
                     type="button"
-                    className="rounded-full px-4 py-2 text-sm font-semibold text-virintira-primary transition hover:bg-virintira-primary/10"
+                    className={`relative font-medium transition ${
+                      isHoveringMenu ? 'text-[#A70909]' : 'text-black'
+                    } after:absolute after:-bottom-6 after:left-0 after:h-[7px] after:w-full after:rounded-t-full after:bg-[#A70909] after:origin-center after:transition-transform ${
+                      isHoveringMenu ? 'after:scale-x-[1.2]' : 'after:scale-x-0'
+                    }`}
                     aria-haspopup="true"
-                    aria-expanded="false"
+                    aria-expanded={isHoveringMenu}
+                    onClick={() => setIsHoveringMenu((prev) => !prev)}
                   >
                     {data.megaMenu.triggerLabel}
                   </button>
-                  <div className="pointer-events-none opacity-0 transition duration-150 ease-out group-hover:pointer-events-auto group-hover:opacity-100">
-                    <MegaMenu columns={data.megaMenu.columns} />
-                  </div>
+                  {isHoveringMenu ? (
+                    <MegaMenu
+                      columns={data.megaMenu.columns}
+                      onMouseEnter={handleOpenMegaMenu}
+                      onMouseLeave={handleCloseMegaMenu}
+                      onLinkClick={() => setIsHoveringMenu(false)}
+                    />
+                  ) : null}
                 </div>
               ) : null}
             </nav>
           </div>
-          <div className="flex items-center gap-3">
+          <div className="hidden items-center gap-4 lg:flex">
             <SearchToggle active={searchOpen} onClick={() => setSearchOpen((prev) => !prev)} />
             <LanguageSwitcher />
-            <a
-              href={`tel:${COMPANY.phone}`}
-              className="hidden rounded-full border border-virintira-primary px-5 py-2 text-sm font-semibold text-virintira-primary transition hover:bg-virintira-primary hover:text-white xl:inline-flex"
-            >
-              {data.ctaPrimary}
-            </a>
-            <a
-              href={COMPANY.socials.line}
-              className="inline-flex items-center rounded-full bg-[#06C755] px-5 py-2 text-sm font-semibold text-white transition hover:brightness-110"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {data.ctaSecondary}
-            </a>
-            <HamburgerButton isOpen={mobileOpen} onClick={() => setMobileOpen(true)} className="xl:hidden" />
+          </div>
+          <div className="flex items-center gap-2 lg:hidden">
+            <SearchToggle active={searchOpen} onClick={() => setSearchOpen((prev) => !prev)} />
+            <LanguageSwitcher />
+            <HamburgerButton isOpen={mobileOpen} onClick={() => setMobileOpen((prev) => !prev)} />
           </div>
         </div>
         {searchOpen ? (
@@ -140,7 +241,7 @@ export function Navbar({ data }: { data: NavbarData }) {
               <input
                 type="search"
                 placeholder="Search accounting resources"
-                className="w-full rounded-full border border-virintira-border px-5 py-3 text-sm focus:border-virintira-primary focus:outline-none focus:ring-2 focus:ring-virintira-primary/20"
+                className="w-full rounded-full border border-virintira-border px-5 py-3 text-sm focus:border-[#A70909] focus:outline-none focus:ring-2 focus:ring-[#A70909]/20"
               />
             </div>
           </div>
@@ -150,8 +251,7 @@ export function Navbar({ data }: { data: NavbarData }) {
         open={mobileOpen}
         nav={data.nav}
         columns={data.megaMenu.columns}
-        ctaPrimary={data.ctaPrimary}
-        ctaSecondary={data.ctaSecondary}
+        triggerLabel={data.megaMenu.triggerLabel}
         onClose={() => setMobileOpen(false)}
       />
     </>

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -1,0 +1,33 @@
+import { i18n, type Locale } from '@/i18n/config';
+
+const EXTERNAL_PATTERN = /^(?:[a-zA-Z][a-zA-Z+.-]*:|\/\/)/;
+
+export function normalizeInternalHref(href: string): string {
+  if (!href) {
+    return '#';
+  }
+
+  const trimmed = href.trim();
+  if (!trimmed || trimmed === '#') {
+    return trimmed || '#';
+  }
+
+  if (trimmed.startsWith('#') || EXTERNAL_PATTERN.test(trimmed)) {
+    return trimmed;
+  }
+
+  const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  const sanitized = withLeadingSlash.replace(/\/+/g, '/');
+
+  const segments = sanitized.split('/').filter(Boolean);
+  if (segments.length > 0 && (i18n.locales as Locale[]).includes(segments[0] as Locale)) {
+    segments.shift();
+  }
+
+  const normalized = `/${segments.join('/')}`;
+  return normalized === '/' ? '/' : normalized.replace(/\/+/g, '/');
+}
+
+export function isExternalHref(href: string): boolean {
+  return EXTERNAL_PATTERN.test(href);
+}


### PR DESCRIPTION
## Summary
- restyle the navbar, mega menu, and mobile menu to match the legacy layout and hover behaviour
- introduce shared link utilities to normalize internal hrefs and avoid double-locale URLs
- update mobile navigation flow to mirror the legacy stacked menu experience

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddfedf54c0832ba72bc570fdfd0e5a