### PR TITLE
Align home layout with legacy section order

### DIFF
--- a/app/[locale]/(pages)/page.tsx
+++ b/app/[locale]/(pages)/page.tsx
@@ -163,7 +163,6 @@ export default async function HomePage({ params }: PageParams) {
       <StructuredData id="jsonld-home" data={webPageJsonLd} />
       <StructuredData id="jsonld-breadcrumb" data={breadcrumbJsonLd} />
       <HeroSection content={hero} chatLabel={chatLabel} />
-      <AboutSection heading={about.heading} paragraphs={about.paragraphs} linkLabel={about.link} />
       <PopularServices heading={services.heading} items={services.items} />
       <WhyChooseUsSection heading={highlights.heading} points={highlights.items} />
       <HowItWorksSection heading={process.heading} steps={process.steps} />
@@ -173,6 +172,7 @@ export default async function HomePage({ params }: PageParams) {
         ctaLabel={promotion.ctaLabel}
         ctaHref={promotion.ctaHref}
       />
+      <AboutSection heading={about.heading} paragraphs={about.paragraphs} linkLabel={about.link} />
       <ContactCTA
         heading={cta.heading}
         description={cta.description}

--- a/src/components/home/AboutSection.tsx
+++ b/src/components/home/AboutSection.tsx
@@ -1,13 +1,15 @@
 import { COMPANY } from '@/data/company';
 
 export function AboutSection({ heading, paragraphs, linkLabel }: { heading: string; paragraphs: string[]; linkLabel: string }) {
+  const details: string[] = Array.isArray(paragraphs) ? paragraphs : [];
+
   return (
     <section className="mx-auto max-w-6xl px-4" id="about">
       <div className="grid gap-12 lg:grid-cols-[1.2fr_1fr] lg:items-start">
         <div className="space-y-6">
           <h2 className="text-[clamp(1.85rem,1.3rem+1.6vw,2.6rem)] font-bold text-virintira-primary">{heading}</h2>
           <div className="space-y-4 text-[clamp(0.95rem,0.9rem+0.3vw,1.1rem)] leading-relaxed text-virintira-muted">
-            {paragraphs.map((paragraph, index) => (
+            {details.map((paragraph, index) => (
               <p key={index} className="indent-6">
                 {paragraph}
               </p>

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -13,6 +13,8 @@ export type HeroContent = {
 };
 
 export function HeroSection({ content, chatLabel }: { content: HeroContent; chatLabel: string }) {
+  const typewriterPhrases: string[] = Array.isArray(content.typewriter) ? content.typewriter : [];
+
   return (
     <section className="relative overflow-hidden bg-virintira-soft" id="hero">
       <div className="absolute inset-0 bg-gradient-to-br from-virintira-soft via-white to-[#fde8e8]" aria-hidden="true" />
@@ -25,7 +27,7 @@ export function HeroSection({ content, chatLabel }: { content: HeroContent; chat
             {content.title}
           </h1>
           <div className="text-[clamp(1.1rem,1rem+0.4vw,1.35rem)] font-semibold text-virintira-primary">
-            <TypewriterText phrases={content.typewriter} />
+            <TypewriterText phrases={typewriterPhrases} />
           </div>
           <p className="text-[clamp(1.1rem,1rem+0.5vw,1.4rem)] font-semibold text-virintira-primary/90">
             {content.subtitle}

--- a/src/components/home/HowItWorksSection.tsx
+++ b/src/components/home/HowItWorksSection.tsx
@@ -4,12 +4,14 @@ export type ProcessStep = {
 };
 
 export function HowItWorksSection({ heading, steps }: { heading: string; steps: ProcessStep[] }) {
+  const processSteps: ProcessStep[] = Array.isArray(steps) ? steps : [];
+
   return (
     <section className="mx-auto max-w-6xl px-4" id="process">
       <div className="space-y-8">
         <h2 className="text-center text-[clamp(1.9rem,1.3rem+1.6vw,2.6rem)] font-bold text-virintira-primary">{heading}</h2>
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-          {steps.map((step, index) => (
+          {processSteps.map((step, index) => (
             <article key={step.title} className="rounded-3xl border border-virintira-border bg-white p-6 shadow-sm">
               <span className="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-full bg-virintira-primary/10 text-sm font-semibold text-virintira-primary">
                 {index + 1}

--- a/src/components/home/PopularServices.tsx
+++ b/src/components/home/PopularServices.tsx
@@ -4,13 +4,15 @@ export type ServiceItem = {
 };
 
 export function PopularServices({ heading, items }: { heading: string; items: ServiceItem[] }) {
+  const services: ServiceItem[] = Array.isArray(items) ? items : [];
+
   return (
     <section className="bg-white" id="services">
       <div className="mx-auto max-w-6xl px-4 py-16">
         <div className="space-y-6 text-center">
           <h2 className="text-[clamp(1.9rem,1.3rem+1.6vw,2.6rem)] font-bold text-virintira-primary">{heading}</h2>
           <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {items.map((item, index) => (
+            {services.map((item, index) => (
               <article
                 key={item.title}
                 className="flex h-full flex-col rounded-3xl border border-virintira-border bg-white p-6 text-left shadow-sm transition hover:-translate-y-1 hover:border-virintira-primary/30 hover:shadow-xl"

--- a/src/components/home/WhyChooseUsSection.tsx
+++ b/src/components/home/WhyChooseUsSection.tsx
@@ -1,11 +1,13 @@
 export function WhyChooseUsSection({ heading, points }: { heading: string; points: string[] }) {
+  const highlights: string[] = Array.isArray(points) ? points : [];
+
   return (
     <section className="mx-auto max-w-6xl px-4" id="why-us">
       <div className="rounded-[36px] bg-gradient-to-br from-virintira-primary to-virintira-primary-dark p-12 text-white shadow-[0_40px_120px_rgba(167,9,9,0.35)]">
         <div className="space-y-8">
           <h2 className="text-center text-[clamp(1.9rem,1.3rem+1.6vw,2.6rem)] font-bold">{heading}</h2>
           <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {points.map((item) => (
+            {highlights.map((item) => (
               <div key={item} className="rounded-3xl bg-white/10 p-6 text-[clamp(0.95rem,0.9rem+0.3vw,1.05rem)] leading-relaxed">
                 {item}
               </div>


### PR DESCRIPTION
## Summary
- reorder the home page sections to match the legacy flow before rendering
- add defensive array handling to home sections to avoid runtime issues when translations are missing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de008afdac832b8e3ae65a3d9e74f8