### PR TITLE
chore: tune nav animations and focus states

### DIFF
--- a/src/components/common/ScrollToHero.tsx
+++ b/src/components/common/ScrollToHero.tsx
@@ -4,9 +4,9 @@ export function ScrollToHero() {
   return (
     <a
       href="#hero"
-      className="group fixed bottom-6 left-6 z-40 hidden items-center gap-2 rounded-full bg-white/80 px-5 py-3 text-sm font-semibold text-virintira-primary shadow-lg backdrop-blur transition hover:-translate-y-0.5 hover:bg-white xl:inline-flex"
+      className="group fixed bottom-6 left-6 z-40 hidden items-center gap-2 rounded-full bg-white/80 px-5 py-3 text-sm font-semibold text-virintira-primary shadow-lg backdrop-blur transition duration-300 ease-out hover:-translate-y-0.5 hover:bg-white focus-visible:ring-2 focus-visible:ring-virintira-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white xl:inline-flex"
     >
-      <span className="inline-block rounded-full bg-virintira-primary px-2 py-1 text-xs text-white transition group-hover:scale-105">↑</span>
+      <span className="inline-block rounded-full bg-virintira-primary px-2 py-1 text-xs text-white transition duration-300 ease-out group-hover:scale-105">↑</span>
       <span>Back to top</span>
     </a>
   );

--- a/src/components/home/ContactCTA.tsx
+++ b/src/components/home/ContactCTA.tsx
@@ -10,7 +10,7 @@ export function ContactCTA({ heading, description, callLabel, chatLabel, emailLa
           <div className="flex flex-col gap-4 sm:flex-row">
             <a
               href={`tel:${COMPANY.phone}`}
-              className="inline-flex min-w-[200px] items-center justify-center rounded-full border border-virintira-primary px-6 py-3 text-sm font-semibold text-virintira-primary transition hover:bg-virintira-primary hover:text-white"
+              className="inline-flex min-w-[200px] items-center justify-center rounded-full border border-virintira-primary px-6 py-3 text-sm font-semibold text-virintira-primary transition-colors duration-200 ease-in-out hover:bg-virintira-primary hover:text-white focus-visible:ring-2 focus-visible:ring-virintira-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white"
             >
               {callLabel}
             </a>
@@ -18,13 +18,13 @@ export function ContactCTA({ heading, description, callLabel, chatLabel, emailLa
               href={COMPANY.socials.line}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex min-w-[200px] items-center justify-center rounded-full bg-[#06C755] px-6 py-3 text-sm font-semibold text-white transition hover:brightness-110"
+              className="inline-flex min-w-[200px] items-center justify-center rounded-full bg-[#06C755] px-6 py-3 text-sm font-semibold text-white transition duration-200 ease-in-out hover:brightness-110 focus-visible:ring-2 focus-visible:ring-[#06C755] focus-visible:ring-offset-2 focus-visible:ring-offset-white"
             >
               {chatLabel}
             </a>
             <a
               href={`mailto:${COMPANY.email}`}
-              className="inline-flex min-w-[200px] items-center justify-center rounded-full bg-virintira-primary px-6 py-3 text-sm font-semibold text-white transition hover:bg-virintira-primary-dark"
+              className="inline-flex min-w-[200px] items-center justify-center rounded-full bg-virintira-primary px-6 py-3 text-sm font-semibold text-white transition-colors duration-200 ease-in-out hover:bg-virintira-primary-dark focus-visible:ring-2 focus-visible:ring-virintira-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white"
             >
               {emailLabel}
             </a>

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -38,13 +38,13 @@ export function HeroSection({ content, chatLabel }: { content: HeroContent; chat
           <div className="flex flex-col items-center gap-4 pt-4 sm:flex-row sm:justify-start">
             <a
               href={`tel:${COMPANY.phone}`}
-              className="inline-flex min-w-[200px] items-center justify-center rounded-full bg-virintira-primary px-6 py-3 text-sm font-semibold text-white shadow transition hover:bg-virintira-primary-dark"
+              className="inline-flex min-w-[200px] items-center justify-center rounded-full bg-virintira-primary px-6 py-3 text-sm font-semibold text-white shadow transition-colors duration-200 ease-in-out hover:bg-virintira-primary-dark focus-visible:ring-2 focus-visible:ring-virintira-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white"
             >
               {content.primary}
             </a>
             <a
               href={COMPANY.socials.line}
-              className="inline-flex min-w-[200px] items-center justify-center rounded-full bg-[#06C755] px-6 py-3 text-sm font-semibold text-white transition hover:brightness-110"
+              className="inline-flex min-w-[200px] items-center justify-center rounded-full bg-[#06C755] px-6 py-3 text-sm font-semibold text-white transition duration-200 ease-in-out hover:brightness-110 focus-visible:ring-2 focus-visible:ring-[#06C755] focus-visible:ring-offset-2 focus-visible:ring-offset-white"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -59,7 +59,7 @@ export function HeroSection({ content, chatLabel }: { content: HeroContent; chat
           <p className="text-sm text-virintira-muted">{COMPANY.legalNameTh}</p>
           <a
             href={`mailto:${COMPANY.email}`}
-            className="inline-flex items-center justify-center rounded-full bg-virintira-primary px-6 py-3 text-sm font-semibold text-white transition hover:bg-virintira-primary-dark"
+            className="inline-flex items-center justify-center rounded-full bg-virintira-primary px-6 py-3 text-sm font-semibold text-white transition-colors duration-200 ease-in-out hover:bg-virintira-primary-dark focus-visible:ring-2 focus-visible:ring-virintira-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white"
           >
             {content.emailButton}
           </a>

--- a/src/components/home/PopularServices.tsx
+++ b/src/components/home/PopularServices.tsx
@@ -15,7 +15,7 @@ export function PopularServices({ heading, items }: { heading: string; items: Se
             {services.map((item, index) => (
               <article
                 key={item.title}
-                className="flex h-full flex-col rounded-3xl border border-virintira-border bg-white p-6 text-left shadow-sm transition hover:-translate-y-1 hover:border-virintira-primary/30 hover:shadow-xl"
+                className="flex h-full flex-col rounded-3xl border border-virintira-border bg-white p-6 text-left shadow-sm transition-transform duration-300 ease-out hover:-translate-y-1 hover:border-virintira-primary/30 hover:shadow-xl"
               >
                 <span className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-full bg-virintira-primary/10 text-sm font-semibold text-virintira-primary">
                   {index + 1}

--- a/src/components/navbar/HamburgerButton.tsx
+++ b/src/components/navbar/HamburgerButton.tsx
@@ -8,18 +8,18 @@ export function HamburgerButton({ isOpen, className = '', ...props }: { isOpen: 
       type="button"
       aria-expanded={isOpen}
       aria-label={isOpen ? 'Close menu' : 'Open menu'}
-      className={`flex h-10 w-10 items-center justify-center rounded-full border border-virintira-border bg-white text-virintira-primary shadow transition hover:border-virintira-primary/60 hover:shadow-lg ${className}`}
+      className={`flex h-10 w-10 items-center justify-center rounded-full border border-virintira-border bg-white text-virintira-primary shadow transition-colors duration-200 ease-in-out hover:border-virintira-primary/60 hover:shadow-lg focus-visible:ring-2 focus-visible:ring-virintira-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white ${className}`}
       {...props}
     >
       <span className="relative block h-4 w-5">
         <span
-          className={`absolute left-1/2 top-0 block h-0.5 w-5 -translate-x-1/2 transform rounded-full bg-current transition ${isOpen ? 'translate-y-2 rotate-45' : ''}`}
+          className={`absolute left-1/2 top-0 block h-0.5 w-5 -translate-x-1/2 transform rounded-full bg-current transition-transform duration-300 ease-in-out ${isOpen ? 'translate-y-2 rotate-45' : ''}`}
         />
         <span
-          className={`absolute left-1/2 top-1/2 block h-0.5 w-5 -translate-x-1/2 -translate-y-1/2 transform rounded-full bg-current transition ${isOpen ? 'opacity-0' : 'opacity-100'}`}
+          className={`absolute left-1/2 top-1/2 block h-0.5 w-5 -translate-x-1/2 -translate-y-1/2 transform rounded-full bg-current transition duration-300 ease-in-out ${isOpen ? 'opacity-0' : 'opacity-100'}`}
         />
         <span
-          className={`absolute left-1/2 bottom-0 block h-0.5 w-5 -translate-x-1/2 transform rounded-full bg-current transition ${isOpen ? '-translate-y-2 -rotate-45' : ''}`}
+          className={`absolute left-1/2 bottom-0 block h-0.5 w-5 -translate-x-1/2 transform rounded-full bg-current transition-transform duration-300 ease-in-out ${isOpen ? '-translate-y-2 -rotate-45' : ''}`}
         />
       </span>
     </button>

--- a/src/components/navbar/MobileMenu.tsx
+++ b/src/components/navbar/MobileMenu.tsx
@@ -104,9 +104,13 @@ export function MobileMenu({
   return (
     <div
       className={`pointer-events-none fixed inset-0 z-50 transition ${open ? 'pointer-events-auto' : ''}`}
+      aria-hidden={!open}
     >
       <div
         ref={containerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Main menu"
         className={`absolute right-0 top-0 h-full w-4/5 max-w-xs transform bg-white shadow-lg transition-transform duration-300 ease-in-out ${
           open ? 'translate-x-0' : 'translate-x-full'
         }`}
@@ -129,7 +133,11 @@ export function MobileMenu({
       <button
         type="button"
         aria-label="Close menu"
-        className={`absolute inset-0 h-full w-full transition ${open ? 'bg-black/20' : 'bg-transparent'}`}
+        tabIndex={open ? 0 : -1}
+        aria-hidden={!open}
+        className={`absolute inset-0 h-full w-full transition-colors duration-300 ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 ${
+          open ? 'bg-black/20' : 'bg-transparent'
+        }`}
         onClick={onClose}
       />
     </div>

--- a/src/components/navbar/MobileMenuView.tsx
+++ b/src/components/navbar/MobileMenuView.tsx
@@ -46,6 +46,7 @@ export function MobileMenuView({
     <div
       className="absolute inset-0 h-full w-full transform transition-transform duration-500 ease-in-out"
       style={{ transform: `translateX(${translate}%)` }}
+      aria-hidden={index !== current}
     >
       <div className="flex h-full w-full flex-col bg-white p-6">
         <div className="mb-4 flex items-center justify-between">
@@ -53,7 +54,7 @@ export function MobileMenuView({
             <button
               type="button"
               onClick={onBack}
-              className="text-lg font-semibold text-[#A70909]"
+              className="text-lg font-semibold text-[#A70909] transition-colors duration-200 ease-in-out focus-visible:ring-2 focus-visible:ring-[#A70909] focus-visible:ring-offset-2 focus-visible:ring-offset-white"
             >
               ←
             </button>
@@ -64,7 +65,7 @@ export function MobileMenuView({
           <button
             type="button"
             onClick={onClose}
-            className="text-2xl font-bold text-[#A70909]"
+            className="text-2xl font-bold text-[#A70909] transition-colors duration-200 ease-in-out focus-visible:ring-2 focus-visible:ring-[#A70909] focus-visible:ring-offset-2 focus-visible:ring-offset-white"
             aria-label="Close menu"
           >
             ✕
@@ -78,7 +79,7 @@ export function MobileMenuView({
                   <button
                     type="button"
                     onClick={() => onSelectSubMenu?.(item.items ?? [], item.label)}
-                    className="w-full text-left text-base font-medium text-black transition hover:text-[#A70909]"
+                    className="w-full text-left text-base font-medium text-black transition-colors duration-200 ease-in-out hover:text-[#A70909] focus-visible:ring-2 focus-visible:ring-[#A70909] focus-visible:ring-offset-2 focus-visible:ring-offset-white"
                   >
                     {item.label}
                   </button>
@@ -105,7 +106,7 @@ export function MobileMenuView({
                   <a
                     href={href}
                     onClick={onClose}
-                    className="block text-base font-medium text-black transition hover:text-[#A70909]"
+                    className="block text-base font-medium text-black transition-colors duration-200 ease-in-out hover:text-[#A70909] focus-visible:ring-2 focus-visible:ring-[#A70909] focus-visible:ring-offset-2 focus-visible:ring-offset-white"
                   >
                     {label}
                   </a>
@@ -119,7 +120,7 @@ export function MobileMenuView({
                 <Link
                   href={normalized}
                   onClick={onClose}
-                  className="block text-base font-medium text-black transition hover:text-[#A70909]"
+                  className="block text-base font-medium text-black transition-colors duration-200 ease-in-out hover:text-[#A70909] focus-visible:ring-2 focus-visible:ring-[#A70909] focus-visible:ring-offset-2 focus-visible:ring-offset-white"
                   prefetch
                 >
                   {label}

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -172,14 +172,18 @@ export function Navbar({ data }: { data: NavbarData }) {
                 const isExternal = isExternalHref(href);
                 const isAnchor = href.startsWith('#');
                 const content = (
-                  <span className="relative font-medium text-black transition hover:text-[#A70909] after:absolute after:-bottom-6 after:left-0 after:h-[7px] after:w-full after:rounded-t-full after:bg-[#A70909] after:origin-center after:scale-x-0 after:transition-transform hover:after:scale-x-[1.2]">
+                  <span className="relative font-medium text-black transition-colors duration-300 ease-in-out hover:text-[#A70909] after:absolute after:-bottom-6 after:left-0 after:h-[7px] after:w-full after:rounded-t-full after:bg-[#A70909] after:origin-center after:scale-x-0 after:transition-transform after:duration-300 hover:after:scale-x-[1.2]">
                     {item.label}
                   </span>
                 );
 
                 if (isExternal || isAnchor) {
                   return (
-                    <a key={item.label} href={href} className="inline-flex items-center">
+                    <a
+                      key={item.label}
+                      href={href}
+                      className="inline-flex items-center focus-visible:ring-2 focus-visible:ring-[#A70909] focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+                    >
                       {content}
                     </a>
                   );
@@ -187,7 +191,12 @@ export function Navbar({ data }: { data: NavbarData }) {
 
                 const normalized = normalizeInternalHref(href);
                 return (
-                  <Link key={item.label} href={normalized} className="inline-flex items-center" prefetch>
+                  <Link
+                    key={item.label}
+                    href={normalized}
+                    className="inline-flex items-center focus-visible:ring-2 focus-visible:ring-[#A70909] focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+                    prefetch
+                  >
                     {content}
                   </Link>
                 );
@@ -202,11 +211,11 @@ export function Navbar({ data }: { data: NavbarData }) {
                 >
                   <button
                     type="button"
-                    className={`relative font-medium transition ${
+                    className={`relative font-medium transition-colors duration-300 ease-in-out ${
                       isHoveringMenu ? 'text-[#A70909]' : 'text-black'
-                    } after:absolute after:-bottom-6 after:left-0 after:h-[7px] after:w-full after:rounded-t-full after:bg-[#A70909] after:origin-center after:transition-transform ${
+                    } after:absolute after:-bottom-6 after:left-0 after:h-[7px] after:w-full after:rounded-t-full after:bg-[#A70909] after:origin-center after:transition-transform after:duration-300 ${
                       isHoveringMenu ? 'after:scale-x-[1.2]' : 'after:scale-x-0'
-                    }`}
+                    } focus-visible:ring-2 focus-visible:ring-[#A70909] focus-visible:ring-offset-2 focus-visible:ring-offset-white`}
                     aria-haspopup="true"
                     aria-expanded={isHoveringMenu}
                     onClick={() => setIsHoveringMenu((prev) => !prev)}

--- a/src/components/navbar/SearchToggle.tsx
+++ b/src/components/navbar/SearchToggle.tsx
@@ -7,7 +7,7 @@ export function SearchToggle({ active, className = '', ...props }: { active: boo
     <button
       type="button"
       aria-pressed={active}
-      className={`hidden h-10 w-10 items-center justify-center rounded-full border border-virintira-border bg-white text-virintira-primary transition hover:border-virintira-primary/60 hover:shadow lg:flex ${active ? 'shadow-inner' : 'shadow'} ${className}`}
+      className={`hidden h-10 w-10 items-center justify-center rounded-full border border-virintira-border bg-white text-virintira-primary transition-colors duration-200 ease-in-out hover:border-virintira-primary/60 hover:shadow lg:flex focus-visible:ring-2 focus-visible:ring-virintira-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white ${active ? 'shadow-inner' : 'shadow'} ${className}`}
       {...props}
     >
       <span className="sr-only">Toggle search</span>

--- a/src/components/navbar/SocialFloating.tsx
+++ b/src/components/navbar/SocialFloating.tsx
@@ -13,7 +13,7 @@ export function SocialFloating() {
         <a
           key={link.label}
           href={link.href}
-          className={`inline-flex min-w-[140px] items-center justify-center rounded-full px-5 py-3 text-sm font-semibold shadow-xl transition hover:-translate-y-0.5 hover:shadow-2xl ${link.color} ${link.text} ${link.border ?? ''}`}
+          className={`inline-flex min-w-[140px] items-center justify-center rounded-full px-5 py-3 text-sm font-semibold shadow-xl transition-transform duration-300 ease-out hover:-translate-y-0.5 hover:shadow-2xl focus-visible:ring-2 focus-visible:ring-virintira-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white ${link.color} ${link.text} ${link.border ?? ''}`}
           target={link.external ? '_blank' : undefined}
           rel={link.external ? 'noopener noreferrer' : undefined}
         >

--- a/src/components/ui/CustomLink.tsx
+++ b/src/components/ui/CustomLink.tsx
@@ -5,7 +5,7 @@ import { Link } from '@/i18n/routing';
 export function CustomLink({ className = '', ...props }: ComponentProps<typeof Link>) {
   return (
     <Link
-      className={`inline-flex items-center justify-center rounded-full border border-virintira-primary px-5 py-2 text-sm font-semibold text-virintira-primary transition hover:bg-virintira-primary hover:text-white ${className}`}
+      className={`inline-flex items-center justify-center rounded-full border border-virintira-primary px-5 py-2 text-sm font-semibold text-virintira-primary transition-colors duration-300 ease-in-out hover:bg-virintira-primary hover:text-white focus-visible:ring-2 focus-visible:ring-virintira-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white ${className}`}
       prefetch
       {...props}
     />

--- a/src/components/ui/PrimaryButton.tsx
+++ b/src/components/ui/PrimaryButton.tsx
@@ -4,7 +4,7 @@ export function PrimaryButton({ className = '', ...props }: ButtonHTMLAttributes
   return (
     <button
       type="button"
-      className={`inline-flex items-center justify-center rounded-full bg-virintira-primary px-6 py-3 text-sm font-semibold text-white shadow transition hover:bg-virintira-primary-dark ${className}`}
+      className={`inline-flex items-center justify-center rounded-full bg-virintira-primary px-6 py-3 text-sm font-semibold text-white shadow transition-colors duration-200 ease-in-out hover:bg-virintira-primary-dark focus-visible:ring-2 focus-visible:ring-virintira-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white ${className}`}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- align CTA and navigation transition timings with the legacy reference
- add focus-visible outlines for interactive controls across header, menus, and CTAs
- mark the mobile menu panel as a dialog and smooth the overlay fade for better accessibility

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de0940eec4832bbafa2b9c4b5ca928