### PR TITLE
feat(nav): align header with legacy design

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -830,3 +830,733 @@ html[dir='rtl'] h3 {
   color: #a70909;
   outline: none;
 }
+
+/* navbar parity overrides */
+.navbar-container {
+  position: fixed;
+  inset: 0 0 auto;
+  z-index: 60;
+  width: 100%;
+  background: rgba(255, 254, 254, 0.97);
+  box-shadow: 0 14px 40px rgba(167, 9, 9, 0.08);
+  border-bottom: 1px solid rgba(167, 9, 9, 0.08);
+  backdrop-filter: blur(14px);
+}
+
+.navbar-announcement {
+  background: #a70909;
+  color: #ffffff;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.navbar-announcement-content {
+  margin: 0 auto;
+  max-width: 1120px;
+  padding: 0.65rem 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem;
+}
+
+.navbar-announcement-text {
+  font-weight: 700;
+}
+
+.navbar-announcement-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  padding: 0.45rem 1.1rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  transition: background 200ms ease, color 200ms ease, border-color 200ms ease;
+}
+
+.navbar-announcement-action:hover,
+.navbar-announcement-action:focus-visible {
+  background: #ffffff;
+  color: #a70909;
+  border-color: rgba(167, 9, 9, 0.25);
+  outline: none;
+}
+
+.navbar-bar {
+  margin: 0 auto;
+  max-width: 1120px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.15rem 1.25rem;
+  gap: 1.5rem;
+}
+
+.navbar-brand-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.85rem;
+  text-decoration: none;
+}
+
+.navbar-brand-text {
+  font-size: 1.3rem;
+  font-weight: 800;
+  color: #a70909;
+  letter-spacing: 0.22em;
+}
+
+.navbar-primary {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  gap: 2.25rem;
+  flex: 1 1 auto;
+}
+
+.navbar-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: #2a2424;
+  transition: color 180ms ease;
+}
+
+.navbar-link:hover,
+.navbar-link:focus-visible,
+.navbar-link.is-active {
+  color: #a70909;
+  outline: none;
+}
+
+.navbar-link-inner {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.navbar-link-icon {
+  color: #a70909;
+  font-size: 0.95rem;
+  animation: navbar-flame 1.5s ease-in-out infinite;
+}
+
+@keyframes navbar-flame {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
+}
+
+.navbar-link-caret {
+  font-size: 0.75rem;
+  transition: transform 160ms ease;
+}
+
+.navbar-link.is-active .navbar-link-caret,
+.navbar-link[aria-expanded='true'] .navbar-link-caret {
+  transform: rotate(180deg);
+}
+
+.nav-underline {
+  position: relative;
+}
+
+.nav-underline::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -18px;
+  height: 6px;
+  border-radius: 9999px;
+  background: currentColor;
+  opacity: 0;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 180ms cubic-bezier(.22, 1, .36, 1), opacity 120ms linear;
+}
+
+.nav-underline:hover::after,
+.nav-underline:focus-visible::after,
+.nav-underline[aria-current='page']::after,
+.nav-underline.is-active::after {
+  opacity: 1;
+  transform: scaleX(1);
+}
+
+.navbar-actions {
+  display: none;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.navbar-search-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.navbar-search-form {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(167, 9, 9, 0.22);
+  background: #ffffff;
+  box-shadow: 0 10px 32px rgba(167, 9, 9, 0.12);
+  padding: 0.3rem 0.35rem 0.3rem 1.35rem;
+  height: 2.85rem;
+}
+
+.navbar-search-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-size: 0.95rem;
+  color: #2a2424;
+}
+
+.navbar-search-input::placeholder {
+  color: rgba(42, 36, 36, 0.55);
+}
+
+.navbar-search-input:focus {
+  outline: none;
+}
+
+.navbar-search-submit {
+  border: none;
+  border-radius: 9999px;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #a70909;
+  color: #ffffff;
+  box-shadow: 0 10px 26px rgba(167, 9, 9, 0.3);
+  transition: background 160ms ease, box-shadow 160ms ease;
+}
+
+.navbar-search-submit:hover,
+.navbar-search-submit:focus-visible {
+  background: #c9341f;
+  outline: none;
+  box-shadow: 0 14px 34px rgba(167, 9, 9, 0.35);
+}
+
+.navbar-search-submit-icon {
+  font-size: 0.95rem;
+}
+
+.navbar-search-toggle-button {
+  display: inline-flex;
+}
+
+.navbar-phone {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(167, 9, 9, 0.2);
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 10px 24px rgba(167, 9, 9, 0.1);
+}
+
+.navbar-phone-icon {
+  font-size: 1.05rem;
+  color: #a70909;
+}
+
+.navbar-phone-text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+}
+
+.navbar-phone-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: rgba(42, 36, 36, 0.65);
+}
+
+.navbar-phone-number {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: #a70909;
+  text-decoration: none;
+}
+
+.navbar-language-wrapper {
+  position: relative;
+}
+
+.navbar-mobile-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.navbar-mobile-search,
+.navbar-mobile-language {
+  color: #a70909;
+}
+
+.navbar-search-mobile {
+  padding: 0 1.25rem;
+  background: rgba(255, 254, 254, 0.97);
+  border-top: 1px solid rgba(167, 9, 9, 0.08);
+  overflow: hidden;
+  max-height: 0;
+  opacity: 0;
+  transition: max-height 220ms cubic-bezier(.22, 1, .36, 1), opacity 160ms ease;
+}
+
+.navbar-search-mobile[data-open='true'] {
+  max-height: 96px;
+  opacity: 1;
+}
+
+.navbar-search-mobile-form {
+  margin: 0.85rem auto 1.1rem;
+  max-width: 600px;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(167, 9, 9, 0.2);
+  background: #ffffff;
+  box-shadow: 0 12px 32px rgba(167, 9, 9, 0.12);
+  padding: 0.45rem 0.6rem 0.45rem 1.1rem;
+}
+
+.navbar-search-mobile-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-size: 0.95rem;
+  color: #2a2424;
+}
+
+.navbar-search-mobile-input::placeholder {
+  color: rgba(42, 36, 36, 0.55);
+}
+
+.navbar-search-mobile-input:focus {
+  outline: none;
+}
+
+.navbar-search-mobile-submit {
+  border: none;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #a70909;
+  color: #ffffff;
+  box-shadow: 0 10px 26px rgba(167, 9, 9, 0.28);
+  transition: background 160ms ease, box-shadow 160ms ease;
+}
+
+.navbar-search-mobile-submit:hover,
+.navbar-search-mobile-submit:focus-visible {
+  background: #c9341f;
+  outline: none;
+  box-shadow: 0 14px 34px rgba(167, 9, 9, 0.32);
+}
+
+@media (min-width: 1024px) {
+  .navbar-primary {
+    display: flex;
+  }
+  .navbar-actions {
+    display: inline-flex;
+  }
+  .navbar-mobile-actions,
+  .navbar-search-mobile {
+    display: none;
+  }
+}
+
+.search-collapse {
+  transition: width 200ms cubic-bezier(.22, 1, .36, 1), opacity 150ms ease;
+  overflow: hidden;
+}
+
+.search-collapse[data-open='false'] {
+  width: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.search-collapse[data-open='true'] {
+  width: 26rem;
+  opacity: 1;
+}
+
+@media (max-width: 1280px) {
+  .search-collapse[data-open='true'] {
+    width: 22rem;
+  }
+}
+
+@media (max-width: 1024px) {
+  .search-collapse[data-open='true'] {
+    width: 100%;
+  }
+}
+
+.language-switcher {
+  position: relative;
+}
+
+.language-switcher-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(167, 9, 9, 0.22);
+  padding: 0.55rem 0.9rem;
+  background: #ffffff;
+  color: #a70909;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  box-shadow: 0 10px 26px rgba(167, 9, 9, 0.12);
+  transition: color 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+}
+
+.language-switcher-trigger:hover,
+.language-switcher-trigger:focus-visible {
+  color: #c9341f;
+  border-color: rgba(167, 9, 9, 0.4);
+  outline: none;
+  box-shadow: 0 14px 34px rgba(167, 9, 9, 0.18);
+}
+
+.language-switcher-icon {
+  font-size: 0.9rem;
+}
+
+.language-switcher-label {
+  display: none;
+}
+
+.language-switcher-caret {
+  font-size: 0.75rem;
+  transition: transform 160ms ease;
+}
+
+.language-switcher-trigger[aria-expanded='true'] .language-switcher-caret {
+  transform: rotate(180deg);
+}
+
+.language-switcher-dropdown {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  right: 0;
+  width: min(18rem, 70vw);
+  max-height: 18rem;
+  overflow-y: auto;
+  border-radius: 1rem;
+  border: 1px solid rgba(167, 9, 9, 0.18);
+  background: #ffffff;
+  box-shadow: 0 24px 48px rgba(167, 9, 9, 0.18);
+  padding: 0.5rem 0.35rem;
+  opacity: 0;
+  transform: translateY(-6px) scale(0.98);
+  transform-origin: top right;
+  pointer-events: none;
+  transition: transform 200ms cubic-bezier(.22, 1, .36, 1), opacity 150ms ease;
+}
+
+.language-switcher-dropdown[data-open='true'] {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.language-switcher-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.language-switcher-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.55rem 0.85rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: transparent;
+  color: #2a2424;
+  font-size: 0.9rem;
+  text-align: left;
+  transition: background 140ms ease, color 140ms ease;
+}
+
+.language-switcher-item[data-selected='true'] {
+  background: rgba(167, 9, 9, 0.1);
+  color: #a70909;
+}
+
+.language-switcher-item:hover,
+.language-switcher-item:focus-visible {
+  background: rgba(167, 9, 9, 0.12);
+  outline: none;
+}
+
+.language-switcher-flag {
+  width: 22px;
+  height: 16px;
+  border-radius: 4px;
+  overflow: hidden;
+  box-shadow: 0 0 0 1px rgba(17, 17, 17, 0.08);
+}
+
+.language-switcher-name {
+  flex: 1;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+@media (min-width: 1024px) {
+  .language-switcher-label {
+    display: inline;
+  }
+}
+
+.social-floating {
+  position: fixed;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+  z-index: 55;
+  display: none;
+  align-items: center;
+  gap: 0;
+}
+
+.social-floating-panel {
+  background: #ffffff;
+  border-radius: 1.75rem 0 0 1.75rem;
+  border: 1px solid rgba(167, 9, 9, 0.18);
+  box-shadow: -6px 24px 48px rgba(167, 9, 9, 0.2);
+  padding: 1.5rem 1.75rem;
+  width: 15rem;
+  transform: translateX(110%);
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 240ms cubic-bezier(.22, 1, .36, 1), opacity 160ms ease;
+}
+
+.social-floating[data-open='true'] .social-floating-panel {
+  transform: translateX(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.social-floating-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.social-floating-title {
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #a70909;
+}
+
+.social-floating-close {
+  border: none;
+  background: transparent;
+  color: rgba(42, 36, 36, 0.45);
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 140ms ease;
+}
+
+.social-floating-close:hover,
+.social-floating-close:focus-visible {
+  color: #a70909;
+  outline: none;
+}
+
+.social-floating-list {
+  list-style: none;
+  margin: 1.15rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.social-floating-link {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 9999px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-decoration: none;
+  color: #ffffff;
+  box-shadow: 0 14px 32px rgba(167, 9, 9, 0.22);
+  transition: transform 160ms ease, box-shadow 160ms ease, filter 160ms ease;
+}
+
+.social-floating-link:hover,
+.social-floating-link:focus-visible {
+  transform: translateX(-4px);
+  filter: brightness(1.05);
+  outline: none;
+  box-shadow: 0 18px 40px rgba(167, 9, 9, 0.28);
+}
+
+.social-floating-link-call {
+  background: #a70909;
+}
+
+.social-floating-link-line {
+  background: #06c755;
+}
+
+.social-floating-link-tiktok {
+  background: #000000;
+}
+
+.social-floating-link-facebook {
+  background: #1877f2;
+}
+
+.social-floating-link-email {
+  background: #ffffff;
+  color: #a70909;
+  border: 1px solid rgba(167, 9, 9, 0.18);
+  box-shadow: 0 12px 28px rgba(167, 9, 9, 0.18);
+}
+
+.social-floating-link-email .social-floating-icon {
+  color: #a70909;
+}
+
+.social-floating-icon {
+  font-size: 1rem;
+}
+
+.social-floating-text {
+  font-size: 0.9rem;
+}
+
+.social-floating-toggle {
+  border: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  padding: 1.6rem 0.7rem 1.1rem;
+  background: #a70909;
+  color: #ffffff;
+  font-weight: 900;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  border-radius: 1.4rem 0 0 1.4rem;
+  cursor: pointer;
+  box-shadow: -6px 20px 44px rgba(167, 9, 9, 0.28);
+  transition: background 160ms ease, box-shadow 160ms ease, transform 220ms cubic-bezier(.22, 1, .36, 1);
+}
+
+.social-floating[data-open='true'] .social-floating-toggle {
+  transform: translateX(-1px);
+}
+
+.social-floating-toggle:hover,
+.social-floating-toggle:focus-visible {
+  background: #c9341f;
+  outline: none;
+}
+
+.social-floating-toggle-text {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  font-size: 0.68rem;
+}
+
+.social-floating-toggle-icon {
+  font-size: 0.85rem;
+  transform: rotate(180deg);
+  transition: transform 160ms ease;
+}
+
+.social-floating[data-open='true'] .social-floating-toggle-icon {
+  transform: rotate(0deg);
+}
+
+@media (min-width: 1024px) {
+  .social-floating {
+    display: inline-flex;
+  }
+}
+
+.navbar-hamburger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(167, 9, 9, 0.25);
+  background: #ffffff;
+  color: #a70909;
+  position: relative;
+  box-shadow: 0 6px 16px rgba(167, 9, 9, 0.12);
+  transition: background 200ms ease, color 200ms ease, box-shadow 200ms ease;
+}
+
+.navbar-hamburger:hover,
+.navbar-hamburger:focus-visible,
+.navbar-hamburger.is-active {
+  background: #a70909;
+  color: #ffffff;
+  box-shadow: 0 12px 30px rgba(167, 9, 9, 0.25);
+  outline: none;
+}
+
+.navbar-hamburger-line {
+  position: absolute;
+  width: 22px;
+  height: 2px;
+  border-radius: 9999px;
+  background: currentColor;
+  transition: transform 250ms ease, opacity 200ms ease;
+}
+

--- a/src/components/navbar/LanguageSwitcher.tsx
+++ b/src/components/navbar/LanguageSwitcher.tsx
@@ -1,66 +1,177 @@
 "use client";
 
-import { useTransition } from 'react';
-import { useLocale } from 'next-intl';
+import Image from 'next/image';
+import { useLocale, useTranslations } from 'next-intl';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faGlobe } from '@fortawesome/free-solid-svg-icons';
+import { faChevronDown, faGlobe } from '@fortawesome/free-solid-svg-icons';
 
 import { i18n, type Locale } from '@/i18n/config';
 import { usePathname, useRouter } from '@/i18n/routing';
 
-const labels: Record<Locale, string> = {
-  th: 'ไทย',
-  en: 'English',
-  fr: 'Français',
-  de: 'Deutsch',
-  nl: 'Nederlands',
-  it: 'Italiano',
-  'zh-Hant': '繁體中文',
-  'zh-Hans': '简体中文',
-  ja: '日本語',
-  ko: '한국어',
-  ms: 'Bahasa Melayu',
-  ta: 'தமிழ்',
-  hi: 'हिन्दी',
-  ar: 'العربية',
-  fa: 'فارسی',
-  he: 'עברית',
+const FLAG_MAP: Partial<Record<Locale, string>> = {
+  th: '/flags/th.png',
+  en: '/flags/en.png',
 };
 
-export function LanguageSwitcher({
-  variant = 'inline',
-}: {
-  variant?: 'inline' | 'pill';
-}) {
+type LanguageSwitcherProps = {
+  className?: string;
+};
+
+export function LanguageSwitcher({ className = '' }: LanguageSwitcherProps) {
   const locale = useLocale() as Locale;
   const router = useRouter();
   const pathname = usePathname();
+  const t = useTranslations('layout.header');
   const [isPending, startTransition] = useTransition();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const listRef = useRef<HTMLUListElement | null>(null);
+
+  const options = useMemo(() => {
+    const translate = t as unknown as (key: string) => string;
+    return i18n.locales.map((code) => ({
+      code,
+      label: translate(`language.options.${code}`),
+      flag: FLAG_MAP[code as Locale] ?? '/flags/en.png',
+    }));
+  }, [t]);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (event: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(event.target as Node)) {
+        close();
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+    };
+  }, [open, close]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        close();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, close]);
+
+  const handleToggle = useCallback(() => {
+    setOpen((prev) => !prev);
+  }, []);
+
+  const handleSelect = useCallback(
+    (nextLocale: Locale) => {
+      if (nextLocale === locale) {
+        close();
+        return;
+      }
+      startTransition(() => {
+        router.replace(pathname, { locale: nextLocale });
+      });
+      close();
+    },
+    [close, locale, pathname, router],
+  );
+
+  const focusByIndex = useCallback((index: number) => {
+    const items = listRef.current?.querySelectorAll<HTMLButtonElement>(
+      '.language-switcher-item',
+    );
+    if (!items?.length) return;
+    const next = ((index % items.length) + items.length) % items.length;
+    items[next]?.focus();
+  }, []);
+
+  const handleItemKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLButtonElement>, index: number) => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        focusByIndex(index + 1);
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        focusByIndex(index - 1);
+      } else if (event.key === 'Home') {
+        event.preventDefault();
+        focusByIndex(0);
+      } else if (event.key === 'End') {
+        event.preventDefault();
+        focusByIndex(Number.MAX_SAFE_INTEGER);
+      }
+    },
+    [focusByIndex],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const firstSelected = listRef.current?.querySelector<HTMLButtonElement>(
+      '[data-selected="true"]',
+    );
+    firstSelected?.focus();
+  }, [open]);
 
   return (
-    <label className={`navbar-language ${variant === 'pill' ? 'navbar-language-pill' : ''}`}>
-      <span className="sr-only">Select language</span>
-      <span aria-hidden className="navbar-language-icon">
-        <FontAwesomeIcon icon={faGlobe} />
-      </span>
-      <select
-        className="navbar-language-select"
-        value={locale}
+    <div ref={containerRef} className={`language-switcher ${className}`}>
+      <button
+        type="button"
+        className="language-switcher-trigger"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={t('language.dropdownLabel')}
+        onClick={handleToggle}
         disabled={isPending}
-        onChange={(event) => {
-          const nextLocale = event.target.value as Locale;
-          startTransition(() => {
-            router.replace(pathname, { locale: nextLocale });
-          });
-        }}
       >
-        {i18n.locales.map((code) => (
-          <option key={code} value={code}>
-            {labels[code]}
-          </option>
-        ))}
-      </select>
-    </label>
+        <FontAwesomeIcon icon={faGlobe} className="language-switcher-icon" />
+        <span className="language-switcher-label">{t('language.label')}</span>
+        <FontAwesomeIcon icon={faChevronDown} className="language-switcher-caret" />
+      </button>
+      <div className="language-switcher-dropdown" data-open={open} role="presentation">
+        <ul
+          ref={listRef}
+          className="language-switcher-list"
+          role="menu"
+          aria-label={t('language.dropdownLabel')}
+        >
+          {options.map(({ code, label, flag }, index) => (
+            <li key={code} role="none">
+              <button
+                type="button"
+                role="menuitemradio"
+                data-selected={code === locale}
+                aria-checked={code === locale}
+                className="language-switcher-item"
+                onClick={() => handleSelect(code as Locale)}
+                disabled={isPending && code !== locale}
+                onKeyDown={(event) => handleItemKeyDown(event, index)}
+              >
+                <span className="language-switcher-flag" aria-hidden>
+                  <Image src={flag} alt="" width={20} height={14} />
+                </span>
+                <span className="language-switcher-name">{label}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
   );
 }

--- a/src/components/navbar/SearchToggle.tsx
+++ b/src/components/navbar/SearchToggle.tsx
@@ -5,19 +5,26 @@ import type { ButtonHTMLAttributes } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMagnifyingGlass, faXmark } from '@fortawesome/free-solid-svg-icons';
 
+type SearchToggleProps = {
+  active: boolean;
+  srLabel: string;
+} & ButtonHTMLAttributes<HTMLButtonElement>;
+
 export function SearchToggle({
   active,
   className = '',
+  srLabel,
   ...props
-}: { active: boolean } & ButtonHTMLAttributes<HTMLButtonElement>) {
+}: SearchToggleProps) {
   return (
     <button
       type="button"
       aria-pressed={active}
+      aria-expanded={active}
       className={`navbar-search-toggle ${active ? 'is-active' : ''} ${className}`}
       {...props}
     >
-      <span className="sr-only">Toggle search</span>
+      <span className="sr-only">{srLabel}</span>
       <FontAwesomeIcon
         icon={active ? faXmark : faMagnifyingGlass}
         className="navbar-search-toggle-icon"

--- a/src/components/navbar/SocialFloating.tsx
+++ b/src/components/navbar/SocialFloating.tsx
@@ -1,25 +1,156 @@
+"use client";
+
+import { useTranslations } from 'next-intl';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronLeft, faEnvelope, faPhone } from '@fortawesome/free-solid-svg-icons';
+import { faFacebookF, faLine, faTiktok } from '@fortawesome/free-brands-svg-icons';
+
 import { COMPANY } from '@/data/company';
 
-const links = [
-  { href: `tel:${COMPANY.phone}`, label: 'Call', color: 'bg-virintira-primary', text: 'text-white' },
-  { href: COMPANY.socials.line, label: 'LINE', color: 'bg-[#06C755]', text: 'text-white', external: true },
-  { href: `mailto:${COMPANY.email}`, label: 'Email', color: 'bg-white', text: 'text-virintira-primary', border: 'border border-virintira-primary/40' },
-];
+type SocialAction = {
+  id: 'call' | 'line' | 'tiktok' | 'facebook' | 'email';
+  href: string;
+  external?: boolean;
+  icon: IconDefinition;
+  className: string;
+};
 
 export function SocialFloating() {
+  const t = useTranslations('layout.header.social');
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const actions = useMemo<SocialAction[]>(
+    () => [
+      {
+        id: 'call',
+        href: `tel:${COMPANY.phone}`,
+        icon: faPhone,
+        className: 'social-floating-link-call',
+      },
+      {
+        id: 'line',
+        href: COMPANY.socials.line,
+        external: true,
+        icon: faLine,
+        className: 'social-floating-link-line',
+      },
+      {
+        id: 'tiktok',
+        href: COMPANY.socials.tiktok,
+        external: true,
+        icon: faTiktok,
+        className: 'social-floating-link-tiktok',
+      },
+      {
+        id: 'facebook',
+        href: COMPANY.socials.facebook,
+        external: true,
+        icon: faFacebookF,
+        className: 'social-floating-link-facebook',
+      },
+      {
+        id: 'email',
+        href: `mailto:${COMPANY.email}`,
+        icon: faEnvelope,
+        className: 'social-floating-link-email',
+      },
+    ],
+    [],
+  );
+
+  const close = useCallback(() => setOpen(false), []);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (event: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(event.target as Node)) {
+        close();
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+    };
+  }, [open, close]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        close();
+      }
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open, close]);
+
+  const toggle = useCallback(() => {
+    setOpen((prev) => !prev);
+  }, []);
+
   return (
-    <div className="fixed bottom-6 right-6 z-40 hidden flex-col gap-3 lg:flex">
-      {links.map((link) => (
-        <a
-          key={link.label}
-          href={link.href}
-          className={`inline-flex min-w-[140px] items-center justify-center rounded-full px-5 py-3 text-sm font-semibold shadow-xl transition-transform duration-300 ease-out hover:-translate-y-0.5 hover:shadow-2xl focus-visible:ring-2 focus-visible:ring-virintira-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white ${link.color} ${link.text} ${link.border ?? ''}`}
-          target={link.external ? '_blank' : undefined}
-          rel={link.external ? 'noopener noreferrer' : undefined}
-        >
-          {link.label}
-        </a>
-      ))}
+    <div ref={containerRef} className="social-floating" data-open={open}>
+      <div
+        id="social-floating-panel"
+        className="social-floating-panel"
+        role="dialog"
+        aria-modal="false"
+        aria-hidden={!open}
+      >
+        <div className="social-floating-header">
+          <span className="social-floating-title">{t('heading')}</span>
+          <button
+            type="button"
+            className="social-floating-close"
+            onClick={close}
+            aria-label={t('closeLabel')}
+          >
+            ×
+          </button>
+        </div>
+        <ul className="social-floating-list" role="menu" aria-label={t('heading')}>
+          {actions.map((action) => (
+            <li key={action.id} role="none">
+              <a
+                href={action.href}
+                className={`social-floating-link ${action.className}`}
+                role="menuitem"
+                target={action.external ? '_blank' : undefined}
+                rel={action.external ? 'noopener noreferrer' : undefined}
+              >
+                <FontAwesomeIcon icon={action.icon} className="social-floating-icon" />
+                <span className="social-floating-text">{t(`links.${action.id}`)}</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <button
+        type="button"
+        className="social-floating-toggle"
+        onClick={toggle}
+        aria-expanded={open}
+        aria-controls="social-floating-panel"
+        aria-label={t('toggleLabel')}
+      >
+        <span className="social-floating-toggle-text" aria-hidden>
+          {t('toggleLabel')}
+        </span>
+        <FontAwesomeIcon icon={faChevronLeft} className="social-floating-toggle-icon" aria-hidden />
+      </button>
     </div>
   );
 }

--- a/src/components/navbar/SubMenu.tsx
+++ b/src/components/navbar/SubMenu.tsx
@@ -10,15 +10,22 @@ import type { SubMenuSection } from './types';
 export type SubMenuProps = {
   sections: SubMenuSection[];
   onItemClick?: () => void;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
 };
 
-function SubMenuComponent({ sections, onItemClick }: SubMenuProps) {
+function SubMenuComponent({ sections, onItemClick, onMouseEnter, onMouseLeave }: SubMenuProps) {
   if (!sections.length) {
     return null;
   }
 
   return (
-    <div className="submenu-popover" role="presentation">
+    <div
+      className="submenu-popover"
+      role="presentation"
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
       <div className="submenu-surface" role="menu">
         {sections.map((section, index) => (
           <div key={`${section.title ?? 'section'}-${index}`} className="submenu-column">

--- a/src/messages/ar.json
+++ b/src/messages/ar.json
@@ -137,7 +137,50 @@
         ]
       },
       "ctaPrimary": "Talk to an expert",
-      "ctaSecondary": "LINE OA"
+      "ctaSecondary": "LINE OA",
+      "search": {
+        "placeholder": "Search accounting resources",
+        "mobilePlaceholder": "Search accounting resources",
+        "toggleLabel": "Toggle search",
+        "submitLabel": "Search"
+      },
+      "language": {
+        "label": "Language",
+        "dropdownLabel": "Select language",
+        "options": {
+          "th": "Thai",
+          "en": "English",
+          "fr": "French",
+          "de": "German",
+          "nl": "Dutch",
+          "it": "Italian",
+          "zh-Hant": "Chinese (Traditional)",
+          "zh-Hans": "Chinese (Simplified)",
+          "ja": "Japanese",
+          "ko": "Korean",
+          "ms": "Malay",
+          "ta": "Tamil",
+          "hi": "Hindi",
+          "ar": "Arabic",
+          "fa": "Persian",
+          "he": "Hebrew"
+        }
+      },
+      "actions": {
+        "phoneLabel": "Call us"
+      },
+      "social": {
+        "heading": "Contact us",
+        "toggleLabel": "Contact us",
+        "closeLabel": "Close contact panel",
+        "links": {
+          "call": "Call",
+          "line": "LINE",
+          "tiktok": "TikTok",
+          "facebook": "Facebook",
+          "email": "Email"
+        }
+      }
     },
     "footer": {
       "tagline": "Your multilingual finance department.",

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -137,7 +137,50 @@
         ]
       },
       "ctaPrimary": "Talk to an expert",
-      "ctaSecondary": "LINE OA"
+      "ctaSecondary": "LINE OA",
+      "search": {
+        "placeholder": "Search accounting resources",
+        "mobilePlaceholder": "Search accounting resources",
+        "toggleLabel": "Toggle search",
+        "submitLabel": "Search"
+      },
+      "language": {
+        "label": "Language",
+        "dropdownLabel": "Select language",
+        "options": {
+          "th": "Thai",
+          "en": "English",
+          "fr": "French",
+          "de": "German",
+          "nl": "Dutch",
+          "it": "Italian",
+          "zh-Hant": "Chinese (Traditional)",
+          "zh-Hans": "Chinese (Simplified)",
+          "ja": "Japanese",
+          "ko": "Korean",
+          "ms": "Malay",
+          "ta": "Tamil",
+          "hi": "Hindi",
+          "ar": "Arabic",
+          "fa": "Persian",
+          "he": "Hebrew"
+        }
+      },
+      "actions": {
+        "phoneLabel": "Call us"
+      },
+      "social": {
+        "heading": "Contact us",
+        "toggleLabel": "Contact us",
+        "closeLabel": "Close contact panel",
+        "links": {
+          "call": "Call",
+          "line": "LINE",
+          "tiktok": "TikTok",
+          "facebook": "Facebook",
+          "email": "Email"
+        }
+      }
     },
     "footer": {
       "tagline": "Your multilingual finance department.",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -272,7 +272,50 @@
         ]
       },
       "ctaPrimary": "Request consultation",
-      "ctaSecondary": "LINE OA"
+      "ctaSecondary": "LINE OA",
+      "search": {
+        "placeholder": "Search accounting resources",
+        "mobilePlaceholder": "Search accounting resources",
+        "toggleLabel": "Toggle search",
+        "submitLabel": "Search"
+      },
+      "language": {
+        "label": "Language",
+        "dropdownLabel": "Select language",
+        "options": {
+          "th": "Thai",
+          "en": "English",
+          "fr": "French",
+          "de": "German",
+          "nl": "Dutch",
+          "it": "Italian",
+          "zh-Hant": "Chinese (Traditional)",
+          "zh-Hans": "Chinese (Simplified)",
+          "ja": "Japanese",
+          "ko": "Korean",
+          "ms": "Malay",
+          "ta": "Tamil",
+          "hi": "Hindi",
+          "ar": "Arabic",
+          "fa": "Persian",
+          "he": "Hebrew"
+        }
+      },
+      "actions": {
+        "phoneLabel": "Call us"
+      },
+      "social": {
+        "heading": "Contact us",
+        "toggleLabel": "Contact us",
+        "closeLabel": "Close contact panel",
+        "links": {
+          "call": "Call",
+          "line": "LINE",
+          "tiktok": "TikTok",
+          "facebook": "Facebook",
+          "email": "Email"
+        }
+      }
     },
     "footer": {
       "tagline": "Your all-in-one accounting and business partner.",

--- a/src/messages/fa.json
+++ b/src/messages/fa.json
@@ -137,7 +137,50 @@
         ]
       },
       "ctaPrimary": "Talk to an expert",
-      "ctaSecondary": "LINE OA"
+      "ctaSecondary": "LINE OA",
+      "search": {
+        "placeholder": "Search accounting resources",
+        "mobilePlaceholder": "Search accounting resources",
+        "toggleLabel": "Toggle search",
+        "submitLabel": "Search"
+      },
+      "language": {
+        "label": "Language",
+        "dropdownLabel": "Select language",
+        "options": {
+          "th": "Thai",
+          "en": "English",
+          "fr": "French",
+          "de": "German",
+          "nl": "Dutch",
+          "it": "Italian",
+          "zh-Hant": "Chinese (Traditional)",
+          "zh-Hans": "Chinese (Simplified)",
+          "ja": "Japanese",
+          "ko": "Korean",
+          "ms": "Malay",
+          "ta": "Tamil",
+          "hi": "Hindi",
+          "ar": "Arabic",
+          "fa": "Persian",
+          "he": "Hebrew"
+        }
+      },
+      "actions": {
+        "phoneLabel": "Call us"
+      },
+      "social": {
+        "heading": "Contact us",
+        "toggleLabel": "Contact us",
+        "closeLabel": "Close contact panel",
+        "links": {
+          "call": "Call",
+          "line": "LINE",
+          "tiktok": "TikTok",
+          "facebook": "Facebook",
+          "email": "Email"
+        }
+      }
     },
     "footer": {
       "tagline": "Your multilingual finance department.",

--- a/src/messages/fr.json
+++ b/src/messages/fr.json
@@ -137,7 +137,50 @@
         ]
       },
       "ctaPrimary": "Talk to an expert",
-      "ctaSecondary": "LINE OA"
+      "ctaSecondary": "LINE OA",
+      "search": {
+        "placeholder": "Search accounting resources",
+        "mobilePlaceholder": "Search accounting resources",
+        "toggleLabel": "Toggle search",
+        "submitLabel": "Search"
+      },
+      "language": {
+        "label": "Language",
+        "dropdownLabel": "Select language",
+        "options": {
+          "th": "Thai",
+          "en": "English",
+          "fr": "French",
+          "de": "German",
+          "nl": "Dutch",
+          "it": "Italian",
+          "zh-Hant": "Chinese (Traditional)",
+          "zh-Hans": "Chinese (Simplified)",
+          "ja": "Japanese",
+          "ko": "Korean",
+          "ms": "Malay",
+          "ta": "Tamil",
+          "hi": "Hindi",
+          "ar": "Arabic",
+          "fa": "Persian",
+          "he": "Hebrew"
+        }
+      },
+      "actions": {
+        "phoneLabel": "Call us"
+      },
+      "social": {
+        "heading": "Contact us",
+        "toggleLabel": "Contact us",
+        "closeLabel": "Close contact panel",
+        "links": {
+          "call": "Call",
+          "line": "LINE",
+          "tiktok": "TikTok",
+          "facebook": "Facebook",
+          "email": "Email"
+        }
+      }
     },
     "footer": {
       "tagline": "Your multilingual finance department.",

--- a/src/messages/he.json
+++ b/src/messages/he.json
@@ -137,7 +137,50 @@
         ]
       },
       "ctaPrimary": "Talk to an expert",
-      "ctaSecondary": "LINE OA"
+      "ctaSecondary": "LINE OA",
+      "search": {
+        "placeholder": "Search accounting resources",
+        "mobilePlaceholder": "Search accounting resources",
+        "toggleLabel": "Toggle search",
+        "submitLabel": "Search"
+      },
+      "language": {
+        "label": "Language",
+        "dropdownLabel": "Select language",
+        "options": {
+          "th": "Thai",
+          "en": "English",
+          "fr": "French",
+          "de": "German",
+          "nl": "Dutch",
+          "it": "Italian",
+          "zh-Hant": "Chinese (Traditional)",
+          "zh-Hans": "Chinese (Simplified)",
+          "ja": "Japanese",
+          "ko": "Korean",
+          "ms": "Malay",
+          "ta": "Tamil",
+          "hi": "Hindi",
+          "ar": "Arabic",
+          "fa": "Persian",
+          "he": "Hebrew"
+        }
+      },
+      "actions": {
+        "phoneLabel": "Call us"
+      },
+      "social": {
+        "heading": "Contact us",
+        "toggleLabel": "Contact us",
+        "closeLabel": "Close contact panel",
+        "links": {
+          "call": "Call",
+          "line": "LINE",
+          "tiktok": "TikTok",
+          "facebook": "Facebook",
+          "email": "Email"
+        }
+      }
     },
     "footer": {
       "tagline": "Your multilingual finance department.",

--- a/src/messages/hi.json
+++ b/src/messages/hi.json
@@ -137,7 +137,50 @@
         ]
       },
       "ctaPrimary": "Talk to an expert",
-      "ctaSecondary": "LINE OA"
+      "ctaSecondary": "LINE OA",
+      "search": {
+        "placeholder": "Search accounting resources",
+        "mobilePlaceholder": "Search accounting resources",
+        "toggleLabel": "Toggle search",
+        "submitLabel": "Search"
+      },
+      "language": {
+        "label": "Language",
+        "dropdownLabel": "Select language",
+        "options": {
+          "th": "Thai",
+          "en": "English",
+          "fr": "French",
+          "de": "German",
+          "nl": "Dutch",
+          "it": "Italian",
+          "zh-Hant": "Chinese (Traditional)",
+          "zh-Hans": "Chinese (Simplified)",
+          "ja": "Japanese",
+          "ko": "Korean",
+          "ms": "Malay",
+          "ta": "Tamil",
+          "hi": "Hindi",
+          "ar": "Arabic",
+          "fa": "Persian",
+          "he": "Hebrew"
+        }
+      },
+      "actions": {
+        "phoneLabel": "Call us"
+      },
+      "social": {
+        "heading": "Contact us",
+        "toggleLabel": "Contact us",
+        "closeLabel": "Close contact panel",
+        "links": {
+          "call": "Call",
+          "line": "LINE",
+          "tiktok": "TikTok",
+          "facebook": "Facebook",
+          "email": "Email"
+        }
+      }
     },
     "footer": {
       "tagline": "Your multilingual finance department.",

--- a/src/messages/it.json
+++ b/src/messages/it.json
@@ -137,7 +137,50 @@
         ]
       },
       "ctaPrimary": "Talk to an expert",
-      "ctaSecondary": "LINE OA"
+      "ctaSecondary": "LINE OA",
+      "search": {
+        "placeholder": "Search accounting resources",
+        "mobilePlaceholder": "Search accounting resources",
+        "toggleLabel": "Toggle search",
+        "submitLabel": "Search"
+      },
+      "language": {
+        "label": "Language",
+        "dropdownLabel": "Select language",
+        "options": {
+          "th": "Thai",
+          "en": "English",
+          "fr": "French",
+          "de": "German",
+          "nl": "Dutch",
+          "it": "Italian",
+          "zh-Hant": "Chinese (Traditional)",
+          "zh-Hans": "Chinese (Simplified)",
+          "ja": "Japanese",
+          "ko": "Korean",
+          "ms": "Malay",
+          "ta": "Tamil",
+          "hi": "Hindi",
+          "ar": "Arabic",
+          "fa": "Persian",
+          "he": "Hebrew"
+        }
+      },
+      "actions": {
+        "phoneLabel": "Call us"
+      },
+      "social": {
+        "heading": "Contact us",
+        "toggleLabel": "Contact us",
+        "closeLabel": "Close contact panel",
+        "links": {
+          "call": "Call",
+          "line": "LINE",
+          "tiktok": "TikTok",
+          "facebook": "Facebook",
+          "email": "Email"
+        }
+      }
     },
     "footer": {
       "tagline": "Your multilingual finance department.",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -137,7 +137,50 @@
         ]
       },
       "ctaPrimary": "Talk to an expert",
-      "ctaSecondary": "LINE OA"
+      "ctaSecondary": "LINE OA",
+      "search": {
+        "placeholder": "Search accounting resources",
+        "mobilePlaceholder": "Search accounting resources",
+        "toggleLabel": "Toggle search",
+        "submitLabel": "Search"
+      },
+      "language": {
+        "label": "Language",
+        "dropdownLabel": "Select language",
+        "options": {
+          "th": "Thai",
+          "en": "English",
+          "fr": "French",
+          "de": "German",
+          "nl": "Dutch",
+          "it": "Italian",
+          "zh-Hant": "Chinese (Traditional)",
+          "zh-Hans": "Chinese (Simplified)",
+          "ja": "Japanese",
+          "ko": "Korean",
+          "ms": "Malay",
+          "ta": "Tamil",
+          "hi": "Hindi",
+          "ar": "Arabic",
+          "fa": "Persian",
+          "he": "Hebrew"
+        }
+      },
+      "actions": {
+        "phoneLabel": "Call us"
+      },
+      "social": {
+        "heading": "Contact us",
+        "toggleLabel": "Contact us",
+        "closeLabel": "Close contact panel",
+        "links": {
+          "call": "Call",
+          "line": "LINE",
+          "tiktok": "TikTok",
+          "facebook": "Facebook",
+          "email": "Email"
+        }
+      }
     },
     "footer": {
       "tagline": "Your multilingual finance department.",

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -137,7 +137,50 @@
         ]
       },
       "ctaPrimary": "Talk to an expert",
-      "ctaSecondary": "LINE OA"
+      "ctaSecondary": "LINE OA",
+      "search": {
+        "placeholder": "Search accounting resources",
+        "mobilePlaceholder": "Search accounting resources",
+        "toggleLabel": "Toggle search",
+        "submitLabel": "Search"
+      },
+      "language": {
+        "label": "Language",
+        "dropdownLabel": "Select language",
+        "options": {
+          "th": "Thai",
+          "en": "English",
+          "fr": "French",
+          "de": "German",
+          "nl": "Dutch",
+          "it": "Italian",
+          "zh-Hant": "Chinese (Traditional)",
+          "zh-Hans": "Chinese (Simplified)",
+          "ja": "Japanese",
+          "ko": "Korean",
+          "ms": "Malay",
+          "ta": "Tamil",
+          "hi": "Hindi",
+          "ar": "Arabic",
+          "fa": "Persian",
+          "he": "Hebrew"
+        }
+      },
+      "actions": {
+        "phoneLabel": "Call us"
+      },
+      "social": {
+        "heading": "Contact us",
+        "toggleLabel": "Contact us",
+        "closeLabel": "Close contact panel",
+        "links": {
+          "call": "Call",
+          "line": "LINE",
+          "tiktok": "TikTok",
+          "facebook": "Facebook",
+          "email": "Email"
+        }
+      }
     },
     "footer": {
       "tagline": "Your multilingual finance department.",

--- a/src/messages/ms.json
+++ b/src/messages/ms.json
@@ -137,7 +137,50 @@
         ]
       },
       "ctaPrimary": "Talk to an expert",
-      "ctaSecondary": "LINE OA"
+      "ctaSecondary": "LINE OA",
+      "search": {
+        "placeholder": "Search accounting resources",
+        "mobilePlaceholder": "Search accounting resources",
+        "toggleLabel": "Toggle search",
+        "submitLabel": "Search"
+      },
+      "language": {
+        "label": "Language",
+        "dropdownLabel": "Select language",
+        "options": {
+          "th": "Thai",
+          "en": "English",
+          "fr": "French",
+          "de": "German",
+          "nl": "Dutch",
+          "it": "Italian",
+          "zh-Hant": "Chinese (Traditional)",
+          "zh-Hans": "Chinese (Simplified)",
+          "ja": "Japanese",
+          "ko": "Korean",
+          "ms": "Malay",
+          "ta": "Tamil",
+          "hi": "Hindi",
+          "ar": "Arabic",
+          "fa": "Persian",
+          "he": "Hebrew"
+        }
+      },
+      "actions": {
+        "phoneLabel": "Call us"
+      },
+      "social": {
+        "heading": "Contact us",
+        "toggleLabel": "Contact us",
+        "closeLabel": "Close contact panel",
+        "links": {
+          "call": "Call",
+          "line": "LINE",
+          "tiktok": "TikTok",
+          "facebook": "Facebook",
+          "email": "Email"
+        }
+      }
     },
     "footer": {
       "tagline": "Your multilingual finance department.",

--- a/src/messages/nl.json
+++ b/src/messages/nl.json
@@ -137,7 +137,50 @@
         ]
       },
       "ctaPrimary": "Talk to an expert",
-      "ctaSecondary": "LINE OA"
+      "ctaSecondary": "LINE OA",
+      "search": {
+        "placeholder": "Search accounting resources",
+        "mobilePlaceholder": "Search accounting resources",
+        "toggleLabel": "Toggle search",
+        "submitLabel": "Search"
+      },
+      "language": {
+        "label": "Language",
+        "dropdownLabel": "Select language",
+        "options": {
+          "th": "Thai",
+          "en": "English",
+          "fr": "French",
+          "de": "German",
+          "nl": "Dutch",
+          "it": "Italian",
+          "zh-Hant": "Chinese (Traditional)",
+          "zh-Hans": "Chinese (Simplified)",
+          "ja": "Japanese",
+          "ko": "Korean",
+          "ms": "Malay",
+          "ta": "Tamil",
+          "hi": "Hindi",
+          "ar": "Arabic",
+          "fa": "Persian",
+          "he": "Hebrew"
+        }
+      },
+      "actions": {
+        "phoneLabel": "Call us"
+      },
+      "social": {
+        "heading": "Contact us",
+        "toggleLabel": "Contact us",
+        "closeLabel": "Close contact panel",
+        "links": {
+          "call": "Call",
+          "line": "LINE",
+          "tiktok": "TikTok",
+          "facebook": "Facebook",
+          "email": "Email"
+        }
+      }
     },
     "footer": {
       "tagline": "Your multilingual finance department.",

--- a/src/messages/ta.json
+++ b/src/messages/ta.json
@@ -137,7 +137,50 @@
         ]
       },
       "ctaPrimary": "Talk to an expert",
-      "ctaSecondary": "LINE OA"
+      "ctaSecondary": "LINE OA",
+      "search": {
+        "placeholder": "Search accounting resources",
+        "mobilePlaceholder": "Search accounting resources",
+        "toggleLabel": "Toggle search",
+        "submitLabel": "Search"
+      },
+      "language": {
+        "label": "Language",
+        "dropdownLabel": "Select language",
+        "options": {
+          "th": "Thai",
+          "en": "English",
+          "fr": "French",
+          "de": "German",
+          "nl": "Dutch",
+          "it": "Italian",
+          "zh-Hant": "Chinese (Traditional)",
+          "zh-Hans": "Chinese (Simplified)",
+          "ja": "Japanese",
+          "ko": "Korean",
+          "ms": "Malay",
+          "ta": "Tamil",
+          "hi": "Hindi",
+          "ar": "Arabic",
+          "fa": "Persian",
+          "he": "Hebrew"
+        }
+      },
+      "actions": {
+        "phoneLabel": "Call us"
+      },
+      "social": {
+        "heading": "Contact us",
+        "toggleLabel": "Contact us",
+        "closeLabel": "Close contact panel",
+        "links": {
+          "call": "Call",
+          "line": "LINE",
+          "tiktok": "TikTok",
+          "facebook": "Facebook",
+          "email": "Email"
+        }
+      }
     },
     "footer": {
       "tagline": "Your multilingual finance department.",

--- a/src/messages/th.json
+++ b/src/messages/th.json
@@ -272,7 +272,50 @@
         ]
       },
       "ctaPrimary": "ขอคำปรึกษาฟรี",
-      "ctaSecondary": "LINE OA"
+      "ctaSecondary": "LINE OA",
+      "search": {
+        "placeholder": "ค้นหาแหล่งความรู้บัญชี",
+        "mobilePlaceholder": "ค้นหาแหล่งความรู้บัญชี",
+        "toggleLabel": "เปิดหรือปิดการค้นหา",
+        "submitLabel": "ค้นหา"
+      },
+      "language": {
+        "label": "ภาษา",
+        "dropdownLabel": "เลือกภาษา",
+        "options": {
+          "th": "ภาษาไทย",
+          "en": "English",
+          "fr": "ภาษาฝรั่งเศส",
+          "de": "ภาษาเยอรมัน",
+          "nl": "ภาษาดัตช์",
+          "it": "ภาษาอิตาลี",
+          "zh-Hant": "ภาษาจีน (ตัวเต็ม)",
+          "zh-Hans": "ภาษาจีน (ตัวย่อ)",
+          "ja": "ภาษาญี่ปุ่น",
+          "ko": "ภาษาเกาหลี",
+          "ms": "ภาษามาเลย์",
+          "ta": "ภาษาทมิฬ",
+          "hi": "ภาษาฮินดี",
+          "ar": "ภาษาอาหรับ",
+          "fa": "ภาษาเปอร์เซีย",
+          "he": "ภาษาฮีบรู"
+        }
+      },
+      "actions": {
+        "phoneLabel": "โทรหาเรา"
+      },
+      "social": {
+        "heading": "ติดต่อเรา",
+        "toggleLabel": "ติดต่อเรา",
+        "closeLabel": "ปิดแถบติดต่อ",
+        "links": {
+          "call": "โทร",
+          "line": "LINE",
+          "tiktok": "TikTok",
+          "facebook": "Facebook",
+          "email": "อีเมล"
+        }
+      }
     },
     "footer": {
       "tagline": "พาร์ตเนอร์บัญชีและธุรกิจครบวงจร",

--- a/src/messages/zh-Hans.json
+++ b/src/messages/zh-Hans.json
@@ -137,7 +137,50 @@
         ]
       },
       "ctaPrimary": "Talk to an expert",
-      "ctaSecondary": "LINE OA"
+      "ctaSecondary": "LINE OA",
+      "search": {
+        "placeholder": "Search accounting resources",
+        "mobilePlaceholder": "Search accounting resources",
+        "toggleLabel": "Toggle search",
+        "submitLabel": "Search"
+      },
+      "language": {
+        "label": "Language",
+        "dropdownLabel": "Select language",
+        "options": {
+          "th": "Thai",
+          "en": "English",
+          "fr": "French",
+          "de": "German",
+          "nl": "Dutch",
+          "it": "Italian",
+          "zh-Hant": "Chinese (Traditional)",
+          "zh-Hans": "Chinese (Simplified)",
+          "ja": "Japanese",
+          "ko": "Korean",
+          "ms": "Malay",
+          "ta": "Tamil",
+          "hi": "Hindi",
+          "ar": "Arabic",
+          "fa": "Persian",
+          "he": "Hebrew"
+        }
+      },
+      "actions": {
+        "phoneLabel": "Call us"
+      },
+      "social": {
+        "heading": "Contact us",
+        "toggleLabel": "Contact us",
+        "closeLabel": "Close contact panel",
+        "links": {
+          "call": "Call",
+          "line": "LINE",
+          "tiktok": "TikTok",
+          "facebook": "Facebook",
+          "email": "Email"
+        }
+      }
     },
     "footer": {
       "tagline": "Your multilingual finance department.",

--- a/src/messages/zh-Hant.json
+++ b/src/messages/zh-Hant.json
@@ -137,7 +137,50 @@
         ]
       },
       "ctaPrimary": "Talk to an expert",
-      "ctaSecondary": "LINE OA"
+      "ctaSecondary": "LINE OA",
+      "search": {
+        "placeholder": "Search accounting resources",
+        "mobilePlaceholder": "Search accounting resources",
+        "toggleLabel": "Toggle search",
+        "submitLabel": "Search"
+      },
+      "language": {
+        "label": "Language",
+        "dropdownLabel": "Select language",
+        "options": {
+          "th": "Thai",
+          "en": "English",
+          "fr": "French",
+          "de": "German",
+          "nl": "Dutch",
+          "it": "Italian",
+          "zh-Hant": "Chinese (Traditional)",
+          "zh-Hans": "Chinese (Simplified)",
+          "ja": "Japanese",
+          "ko": "Korean",
+          "ms": "Malay",
+          "ta": "Tamil",
+          "hi": "Hindi",
+          "ar": "Arabic",
+          "fa": "Persian",
+          "he": "Hebrew"
+        }
+      },
+      "actions": {
+        "phoneLabel": "Call us"
+      },
+      "social": {
+        "heading": "Contact us",
+        "toggleLabel": "Contact us",
+        "closeLabel": "Close contact panel",
+        "links": {
+          "call": "Call",
+          "line": "LINE",
+          "tiktok": "TikTok",
+          "facebook": "Facebook",
+          "email": "Email"
+        }
+      }
     },
     "footer": {
       "tagline": "Your multilingual finance department.",


### PR DESCRIPTION
## Summary
- restyle the navbar to match the legacy layout, including centered primary links, animated underline states, and inline search expansion on desktop
- replace the language selector with a globe-triggered dropdown that lists all locales using localized labels, and update locale strings across languages
- rebuild the social floating widget as the legacy slide-out contact rail and add supporting global styles for search, language, and contact elements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de6f635d20832bacd6faa8b860edb1