### PR TITLE
Refine header layout spacing

### DIFF
--- a/app/[locale]/(components)/HeaderSpacer.tsx
+++ b/app/[locale]/(components)/HeaderSpacer.tsx
@@ -1,0 +1,3 @@
+export default function HeaderSpacer() {
+  return <div className="h-[72px]" aria-hidden />;
+}

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -7,6 +7,7 @@ import { AnalyticsManager } from '@/components/common/AnalyticsManager';
 import { BusinessJsonLd } from '@/components/common/JsonLd';
 import Footer, { type FooterData, type FooterLink } from '@/components/layout/Footer';
 import Header from '@/components/layout/Header';
+import HeaderSpacer from './(components)/HeaderSpacer';
 import type {
   MegaMenuColumn,
   NavItem,
@@ -186,6 +187,7 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
       <BusinessJsonLd locale={locale} />
       <div className="flex min-h-screen flex-col">
         <Header data={navbar} />
+        <HeaderSpacer />
         <main className="flex-1">{children}</main>
         <Footer data={footer} />
       </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,8 +4,10 @@ import Navbar from '../navbar/Navbar';
 
 export default function Header({ data }: { data: NavbarData }) {
   return (
-    <header className="sticky top-0 z-50 border-b border-black/5 bg-white shadow-header [--nav-h:72px]">
-      <Navbar data={data} />
+    <header className="fixed inset-x-0 top-0 z-50 border-b border-virintira-border bg-white/80 shadow-header backdrop-blur [--nav-h:72px]">
+      <div className="mx-auto flex h-[72px] w-full max-w-[1280px] items-center px-5 sm:px-6 lg:px-8">
+        <Navbar data={data} />
+      </div>
     </header>
   );
 }

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -309,12 +309,12 @@ export function Navbar({ data }: { data: NavbarData }) {
   }, [searchOpen]);
 
   const linkBaseClasses =
-    "group relative flex h-full items-center whitespace-nowrap px-3 text-[15px] font-medium tracking-[0.02em] text-[#211E1E] transition-colors duration-200 hover:text-[#A70909] aria-[current=page]:text-[#A70909] aria-[expanded=true]:text-[#A70909] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#A70909]/30 after:absolute after:left-0 after:right-0 after:-bottom-[22px] after:h-[4px] after:rounded-full after:bg-transparent after:content-[''] after:origin-left after:scale-x-0 after:transition-transform after:duration-200 hover:after:bg-[#A70909] hover:after:scale-x-100 aria-[current=page]:after:bg-[#A70909] aria-[current=page]:after:scale-x-100 aria-[expanded=true]:after:bg-[#A70909] aria-[expanded=true]:after:scale-x-100";
+    "group relative flex h-full items-center whitespace-nowrap px-3 text-[15px] font-medium tracking-[0.02em] text-[#211E1E] transition-colors duration-200 hover:text-[#A70909] aria-[current=page]:text-[#A70909] aria-[expanded=true]:text-[#A70909] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#A70909]/30 after:absolute after:left-0 after:right-0 after:-bottom-[18px] after:h-[4px] after:rounded-full after:bg-transparent after:content-[''] after:origin-left after:scale-x-0 after:transition-transform after:duration-200 hover:after:bg-[#A70909] hover:after:scale-x-100 aria-[current=page]:after:bg-[#A70909] aria-[current=page]:after:scale-x-100 aria-[expanded=true]:after:bg-[#A70909] aria-[expanded=true]:after:scale-x-100";
 
   return (
     <>
       <SocialFloating />
-      <div className="mx-auto flex h-[var(--nav-h)] w-full max-w-[1280px] items-center gap-6 px-5 sm:px-6 lg:px-8">
+      <div className="flex h-full w-full items-center gap-6">
         <Link
           href="/"
           className="flex shrink-0 items-center gap-3"


### PR DESCRIPTION
## Summary
- make the layout header a fixed, blurred bar with centered content
- add a HeaderSpacer helper and adjust navbar underline to align with the fixed bar

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df8fc1ef2c832ba5986ef6b5e08af9