### PR TITLE
Adjust language dropdown spacing and scrolling

### DIFF
--- a/src/components/navbar/LanguageSwitcher.tsx
+++ b/src/components/navbar/LanguageSwitcher.tsx
@@ -141,13 +141,13 @@ export function LanguageSwitcher({ className = '' }: LanguageSwitcherProps) {
         <FontAwesomeIcon icon={faGlobe} />
       </button>
       <div
-        className="absolute right-0 top-full z-50 mt-2 w-32 rounded-2xl border border-black/10 bg-white shadow-xl transition-transform duration-150 ease-out data-[open=false]:pointer-events-none data-[open=false]:-translate-y-1 data-[open=false]:opacity-0 data-[open=true]:translate-y-0 data-[open=true]:opacity-100"
+        className="absolute right-0 top-[calc(100%+0.5rem)] z-50 mt-0 w-44 rounded-xl border border-black/10 bg-white shadow-xl transition-transform duration-150 ease-out data-[open=false]:pointer-events-none data-[open=false]:-translate-y-1 data-[open=false]:opacity-0 data-[open=true]:translate-y-0 data-[open=true]:opacity-100"
         data-open={open}
         role="presentation"
       >
         <ul
           ref={listRef}
-          className="flex flex-col gap-1 p-2"
+          className="flex max-h-[70vh] flex-col gap-1 overflow-y-auto p-2"
           role="menu"
           aria-label={t('language.dropdownLabel')}
         >


### PR DESCRIPTION
## Summary
- align the language dropdown container with the legacy sizing and positioning
- keep the language list uppercase styling while adding an internal scrollable region

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df99052c54832bb78cf5942a908740