### PR TITLE
Refactor navbar underline styling

### DIFF
--- a/src/components/navbar/NavLink.tsx
+++ b/src/components/navbar/NavLink.tsx
@@ -37,7 +37,7 @@ export default function NavLink({
   ariaExpanded,
 }: NavLinkProps) {
   const baseClasses =
-    'group nav-underline text-[17px] font-semibold leading-none tracking-tight text-[var(--nav-text)] transition-colors duration-200 hover:text-[var(--brand-red)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-red)]/30';
+    "group relative text-[17px] font-semibold leading-none tracking-tight text-[var(--nav-text)] transition-colors duration-200 hover:text-[var(--brand-red)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-red)]/30 after:absolute after:-bottom-6 after:left-0 after:right-0 after:h-[7px] after:rounded-full after:bg-[#A70909] after:content-[''] after:origin-left after:scale-x-0 after:transition-transform after:duration-200 group-hover:after:scale-[1.2] aria-[current=page]:text-[var(--brand-red)] aria-expanded:text-[var(--brand-red)] aria-[current=page]:after:scale-[1.2] aria-expanded:after:scale-[1.2]";
   const classes = active ? `${baseClasses} text-[var(--brand-red)]` : baseClasses;
 
   return (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -16,37 +16,6 @@
   --font-size-h3: clamp(1.35rem, 1.1rem + 0.8vw, 1.85rem);
 }
 
-@layer components {
-  .nav-underline {
-    position: relative;
-  }
-  .nav-underline::after {
-    content: '';
-    position: absolute;
-    left: 0;
-    right: 0;
-    height: 3px;
-    background: var(--brand-red);
-    bottom: -1px;
-    transform: scaleX(0);
-    transform-origin: left;
-    transition: transform 0.22s ease;
-  }
-  .nav-underline:hover::after,
-  .nav-underline[aria-current='page']::after,
-  .nav-underline[aria-expanded='true']::after {
-    transform: scaleX(1);
-  }
-
-  .nav-pop {
-    position: fixed;
-    left: 0;
-    right: 0;
-    top: var(--header-h);
-    z-index: 60;
-  }
-}
-
 body {
   font-family: var(--font-inter), system-ui, -apple-system, 'Segoe UI', Arial, sans-serif;
   font-size: var(--font-size-body);


### PR DESCRIPTION
## Summary
- remove legacy navbar helper classes from the global stylesheet
- restyle NavLink to render the underline indicator with Tailwind pseudo-element utilities
- ensure active and expanded states immediately show the red indicator bar via aria-based variants

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e00bbf3560832bbd6ca1bc14aa9c33