### PR TITLE
Adjust navbar overlays to use Tailwind positioning

### DIFF
--- a/src/components/navbar/LanguageSwitcher.tsx
+++ b/src/components/navbar/LanguageSwitcher.tsx
@@ -92,38 +92,35 @@ export default function LanguageSwitcher({
 
       <div
         id="language-menu-panel"
-        className="nav-pop pointer-events-none data-[open=true]:pointer-events-auto"
+        className="pointer-events-none absolute top-full right-0 z-40 mt-4 opacity-0 transition-opacity duration-150 ease-out data-[open=true]:pointer-events-auto data-[open=true]:opacity-100"
         data-open={open ? 'true' : 'false'}
         aria-hidden={open ? undefined : 'true'}
-        style={{ opacity: open ? 1 : 0, transition: 'opacity 150ms ease-out' }}
       >
-        <div className="flex justify-center">
-          <div
-            ref={panelRef}
-            className="w-[min(360px,92vw)] rounded-2xl bg-[var(--surface)] p-2 shadow-[var(--shadow-lg)]"
-          >
-            <ul className="max-h-[60vh] overflow-y-auto">
-              {codes.map((code) => {
-                const normalized = code.toLowerCase();
-                const href = `/${normalized}`;
-                const isActive = normalized === currentLocale.toLowerCase();
-                const itemClasses = isActive
-                  ? 'block rounded-xl px-4 py-2 text-[16px] font-semibold text-[var(--brand-red)] bg-gray-100'
-                  : 'block rounded-xl px-4 py-2 text-[16px] font-semibold text-[var(--nav-text)] transition-colors duration-150 hover:bg-gray-100';
-                return (
-                  <li key={code}>
-                    <Link
-                      href={href}
-                      className={itemClasses}
-                      onClick={() => onOpenChange(false)}
-                    >
-                      {normalized.toUpperCase()}
-                    </Link>
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
+        <div
+          ref={panelRef}
+          className="w-[min(360px,92vw)] rounded-xl bg-[var(--surface)] p-2 shadow-2xl"
+        >
+          <ul className="max-h-80 overflow-y-auto">
+            {codes.map((code) => {
+              const normalized = code.toLowerCase();
+              const href = `/${normalized}`;
+              const isActive = normalized === currentLocale.toLowerCase();
+              const itemClasses = isActive
+                ? 'block rounded-xl px-4 py-2 text-[16px] font-semibold text-[var(--brand-red)] bg-gray-100'
+                : 'block rounded-xl px-4 py-2 text-[16px] font-semibold text-[var(--nav-text)] transition-colors duration-150 hover:bg-gray-100';
+              return (
+                <li key={code}>
+                  <Link
+                    href={href}
+                    className={itemClasses}
+                    onClick={() => onOpenChange(false)}
+                  >
+                    {normalized.toUpperCase()}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
         </div>
       </div>
     </>

--- a/src/components/navbar/MegaMenu.tsx
+++ b/src/components/navbar/MegaMenu.tsx
@@ -24,12 +24,11 @@ export default function MegaMenu({
   return (
     <div
       id="mega-menu-panel"
-      className="nav-pop pointer-events-none transition-opacity duration-150 ease-out"
+      className="pointer-events-none absolute left-0 right-0 top-full z-40 flex justify-center pt-5 opacity-0 transition-opacity duration-150 ease-out data-[open=true]:pointer-events-auto data-[open=true]:opacity-100"
       data-open={open ? 'true' : 'false'}
-      style={{ opacity: open ? 1 : 0 }}
     >
       <div
-        className="pointer-events-auto mx-auto max-w-[1280px] rounded-xl bg-[var(--surface)] p-8 shadow-[var(--shadow-lg)]"
+        className="pointer-events-auto w-full max-w-[1280px] rounded-xl bg-[var(--surface)] p-8 shadow-[var(--shadow-lg)]"
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
       >

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -159,7 +159,7 @@ export default function Navbar({ data }: NavbarProps) {
   return (
     <header className="sticky top-0 z-50 bg-[var(--surface)] shadow-sm">
       <SocialFloating />
-      <div className="mx-auto max-w-[1280px] px-4">
+      <div className="relative mx-auto max-w-[1280px] px-4">
         <div className="flex h-[var(--header-h)] items-center justify-between">
           <Link href={`/${locale}`} className="flex items-center gap-3" prefetch>
             <Image src="/logo.png" alt="ViRINTIRA" width={44} height={44} priority />
@@ -239,23 +239,23 @@ export default function Navbar({ data }: NavbarProps) {
             </div>
           </div>
         </div>
+        {hasMegaMenu ? (
+          <MegaMenu
+            open={megaOpen}
+            columns={megaColumns}
+            onMouseEnter={(event) => {
+              void event;
+              cancelMegaClose();
+              setMegaOpen(true);
+            }}
+            onMouseLeave={(event) => {
+              void event;
+              scheduleMegaClose();
+            }}
+            onLinkClick={() => setMegaOpen(false)}
+          />
+        ) : null}
       </div>
-      {hasMegaMenu ? (
-        <MegaMenu
-          open={megaOpen}
-          columns={megaColumns}
-          onMouseEnter={(event) => {
-            void event;
-            cancelMegaClose();
-            setMegaOpen(true);
-          }}
-          onMouseLeave={(event) => {
-            void event;
-            scheduleMegaClose();
-          }}
-          onLinkClick={() => setMegaOpen(false)}
-        />
-      ) : null}
       <MobileMenu
         open={mobileOpen}
         nav={data.nav}

--- a/src/components/navbar/SearchToggle.tsx
+++ b/src/components/navbar/SearchToggle.tsx
@@ -132,40 +132,37 @@ export default function SearchToggle({
 
       <div
         id="navbar-search-panel"
-        className="nav-pop pointer-events-none data-[open=true]:pointer-events-auto"
+        className="pointer-events-none absolute left-1/2 top-full z-40 flex w-full -translate-x-1/2 justify-center pt-4 opacity-0 transition-opacity duration-150 ease-out data-[open=true]:pointer-events-auto data-[open=true]:opacity-100"
         data-open={open ? 'true' : 'false'}
         aria-hidden={open ? undefined : 'true'}
-        style={{ opacity: open ? 1 : 0, transition: 'opacity 150ms ease-out' }}
       >
-        <div className="flex justify-center">
-          <div
-            ref={shellRef}
-            className="w-[min(920px,92vw)] rounded-full bg-[var(--surface)] px-4 py-2 shadow-[var(--shadow-lg)]"
+        <div
+          ref={shellRef}
+          className="w-[min(920px,92vw)] rounded-full bg-[var(--surface)] px-4 py-2 shadow-[var(--shadow-lg)]"
+        >
+          <form
+            action={action}
+            method="get"
+            className="flex items-center gap-3"
+            onSubmit={handleSubmit}
           >
-            <form
-              action={action}
-              method="get"
-              className="flex items-center gap-3"
-              onSubmit={handleSubmit}
+            <FontAwesomeIcon icon={faSearch} className="h-5 w-5 text-[var(--nav-muted)]" />
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              name="q"
+              autoComplete="off"
+              placeholder={placeholder}
+              className="h-10 w-full bg-transparent text-[17px] leading-none text-[var(--nav-text)] outline-none placeholder:text-[var(--nav-muted)]"
+            />
+            <button
+              type="submit"
+              className="rounded-full bg-[var(--brand-red)] px-5 py-1.5 text-sm font-semibold text-white transition-opacity duration-150 hover:brightness-110"
             >
-              <FontAwesomeIcon icon={faSearch} className="h-5 w-5 text-[var(--nav-muted)]" />
-              <input
-                ref={inputRef}
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                name="q"
-                autoComplete="off"
-                placeholder={placeholder}
-                className="h-10 w-full bg-transparent text-[17px] leading-none text-[var(--nav-text)] outline-none placeholder:text-[var(--nav-muted)]"
-              />
-              <button
-                type="submit"
-                className="rounded-full bg-[var(--brand-red)] px-5 py-1.5 text-sm font-semibold text-white transition-opacity duration-150 hover:brightness-110"
-              >
-                {submitLabel}
-              </button>
-            </form>
-          </div>
+              {submitLabel}
+            </button>
+          </form>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
- anchor the desktop navbar container so dropdowns can position relative to it
- restyle the search, mega menu, and language panels with Tailwind utilities instead of the nav-pop helper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e00c902928832bb2bc220df16a15ce