### PR TITLE
Replace navbar CSS variables with Tailwind tokens

### DIFF
--- a/src/components/navbar/HamburgerButton.tsx
+++ b/src/components/navbar/HamburgerButton.tsx
@@ -8,9 +8,9 @@ type HamburgerButtonProps = {
 
 export default function HamburgerButton({ isOpen, className = '', ...props }: HamburgerButtonProps) {
   const baseClasses =
-    'relative flex h-10 w-10 items-center justify-center rounded-full border border-[var(--brand-red)]/25 bg-white text-[var(--brand-red)] shadow-[0_4px_8px_rgba(167,9,9,0.12)] transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-red)]/40 hover:bg-[var(--brand-red)] hover:text-white';
+    'relative flex h-10 w-10 items-center justify-center rounded-full border border-[#A70909]/25 bg-white text-[#A70909] shadow-[0_4px_8px_rgba(167,9,9,0.12)] transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#A70909]/40 hover:bg-[#A70909] hover:text-white';
   const activeClasses = isOpen
-    ? 'bg-[var(--brand-red)] text-white shadow-[0_12px_30px_rgba(167,9,9,0.25)]'
+    ? 'bg-[#A70909] text-white shadow-[0_12px_30px_rgba(167,9,9,0.25)]'
     : '';
   const lineBase =
     'absolute h-0.5 w-6 rounded-full bg-current transition-all duration-200 ease-out-soft';

--- a/src/components/navbar/LanguageSwitcher.tsx
+++ b/src/components/navbar/LanguageSwitcher.tsx
@@ -85,7 +85,7 @@ export default function LanguageSwitcher({
         aria-expanded={open}
         aria-controls="language-menu-panel"
         onClick={() => onOpenChange(!open)}
-        className="rounded-full p-2 text-[var(--nav-text)] transition-colors duration-150 hover:bg-gray-100"
+        className="rounded-full p-2 text-[#2A2A2A] transition-colors duration-150 hover:bg-gray-100"
       >
         <FontAwesomeIcon icon={faGlobe} className="h-5 w-5" />
       </button>
@@ -98,7 +98,7 @@ export default function LanguageSwitcher({
       >
         <div
           ref={panelRef}
-          className="w-[min(360px,92vw)] rounded-xl bg-[var(--surface)] p-2 shadow-2xl"
+          className="w-[min(360px,92vw)] rounded-xl bg-white p-2 shadow-2xl"
         >
           <ul className="max-h-80 overflow-y-auto">
             {codes.map((code) => {
@@ -106,8 +106,8 @@ export default function LanguageSwitcher({
               const href = `/${normalized}`;
               const isActive = normalized === currentLocale.toLowerCase();
               const itemClasses = isActive
-                ? 'block rounded-xl px-4 py-2 text-[16px] font-semibold text-[var(--brand-red)] bg-gray-100'
-                : 'block rounded-xl px-4 py-2 text-[16px] font-semibold text-[var(--nav-text)] transition-colors duration-150 hover:bg-gray-100';
+                ? 'block rounded-xl px-4 py-2 text-[16px] font-semibold text-[#A70909] bg-gray-100'
+                : 'block rounded-xl px-4 py-2 text-[16px] font-semibold text-[#2A2A2A] transition-colors duration-150 hover:bg-gray-100';
               return (
                 <li key={code}>
                   <Link

--- a/src/components/navbar/MegaMenu.tsx
+++ b/src/components/navbar/MegaMenu.tsx
@@ -28,7 +28,7 @@ export default function MegaMenu({
       data-open={open ? 'true' : 'false'}
     >
       <div
-        className="pointer-events-auto w-full max-w-[1280px] rounded-xl bg-[var(--surface)] p-8 shadow-[var(--shadow-lg)]"
+        className="pointer-events-auto w-full max-w-[1280px] rounded-xl bg-white p-8 shadow-[0_10px_25px_rgba(0,0,0,0.08)]"
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
       >
@@ -36,11 +36,11 @@ export default function MegaMenu({
           {columns.map((column) => (
             <div key={column.title} className="flex flex-col gap-3">
               <div>
-                <p className="text-sm font-semibold uppercase tracking-[0.16em] text-[var(--brand-red)]">
+                <p className="text-sm font-semibold uppercase tracking-[0.16em] text-[#A70909]">
                   {column.title}
                 </p>
                 {column.subtitle ? (
-                  <p className="mt-1 text-sm text-[var(--nav-muted)]">{column.subtitle}</p>
+                  <p className="mt-1 text-sm text-[#6B7280]">{column.subtitle}</p>
                 ) : null}
               </div>
               <ul className="flex flex-col gap-2">
@@ -48,12 +48,12 @@ export default function MegaMenu({
                   <li key={item.href}>
                     <Link
                       href={item.href}
-                      className="block text-[15px] font-medium text-[var(--nav-text)] transition-colors duration-150 hover:text-[var(--brand-red)]"
+                      className="block text-[15px] font-medium text-[#2A2A2A] transition-colors duration-150 hover:text-[#A70909]"
                       onClick={onLinkClick}
                     >
                       <span className="block leading-snug">{item.label}</span>
                       {item.description ? (
-                        <span className="text-sm text-[var(--nav-muted)]">{item.description}</span>
+                        <span className="text-sm text-[#6B7280]">{item.description}</span>
                       ) : null}
                     </Link>
                   </li>

--- a/src/components/navbar/MobileMenuView.tsx
+++ b/src/components/navbar/MobileMenuView.tsx
@@ -40,14 +40,14 @@ export default function MobileMenuView({
         {onBack ? (
           <button
             type="button"
-            className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 text-[var(--nav-text)]"
+            className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 text-[#2A2A2A]"
             onClick={onBack}
             aria-label="Back"
           >
             <FontAwesomeIcon icon={faChevronLeft} />
           </button>
         ) : null}
-        <span className="text-lg font-semibold text-[var(--nav-text)]">{title}</span>
+        <span className="text-lg font-semibold text-[#2A2A2A]">{title}</span>
       </div>
       <ul className="flex flex-col gap-4">
         {items.map((item) => {
@@ -60,9 +60,9 @@ export default function MobileMenuView({
                   className="flex w-full flex-col items-start gap-1 text-left"
                   onClick={() => onSelectSubMenu(item.items, item.label)}
                 >
-                  <span className="text-base font-semibold text-[var(--nav-text)]">{item.label}</span>
+                  <span className="text-base font-semibold text-[#2A2A2A]">{item.label}</span>
                   {item.description ? (
-                    <span className="text-sm text-[var(--nav-muted)]">{item.description}</span>
+                    <span className="text-sm text-[#6B7280]">{item.description}</span>
                   ) : null}
                 </button>
               </li>
@@ -77,9 +77,9 @@ export default function MobileMenuView({
                   className="flex flex-col gap-1 text-left"
                   onClick={onClose}
                 >
-                  <span className="text-base font-semibold text-[var(--nav-text)]">{item.label}</span>
+                  <span className="text-base font-semibold text-[#2A2A2A]">{item.label}</span>
                   {item.description ? (
-                    <span className="text-sm text-[var(--nav-muted)]">{item.description}</span>
+                    <span className="text-sm text-[#6B7280]">{item.description}</span>
                   ) : null}
                 </Link>
               </li>
@@ -88,9 +88,9 @@ export default function MobileMenuView({
 
           return (
             <li key={item.label}>
-              <span className="text-base font-semibold text-[var(--nav-text)]">{item.label}</span>
+              <span className="text-base font-semibold text-[#2A2A2A]">{item.label}</span>
               {item.description ? (
-                <span className="text-sm text-[var(--nav-muted)]">{item.description}</span>
+                <span className="text-sm text-[#6B7280]">{item.description}</span>
               ) : null}
             </li>
           );

--- a/src/components/navbar/NavLink.tsx
+++ b/src/components/navbar/NavLink.tsx
@@ -37,8 +37,8 @@ export default function NavLink({
   ariaExpanded,
 }: NavLinkProps) {
   const baseClasses =
-    "group relative text-[17px] font-semibold leading-none tracking-tight text-[var(--nav-text)] transition-colors duration-200 hover:text-[var(--brand-red)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-red)]/30 after:absolute after:-bottom-6 after:left-0 after:right-0 after:h-[7px] after:rounded-full after:bg-[#A70909] after:content-[''] after:origin-left after:scale-x-0 after:transition-transform after:duration-200 group-hover:after:scale-[1.2] aria-[current=page]:text-[var(--brand-red)] aria-expanded:text-[var(--brand-red)] aria-[current=page]:after:scale-[1.2] aria-expanded:after:scale-[1.2]";
-  const classes = active ? `${baseClasses} text-[var(--brand-red)]` : baseClasses;
+    "group relative text-[17px] font-semibold leading-none tracking-tight text-[#2A2A2A] transition-colors duration-200 hover:text-[#A70909] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#A70909]/30 after:absolute after:-bottom-6 after:left-0 after:right-0 after:h-[7px] after:rounded-full after:bg-[#A70909] after:content-[''] after:origin-left after:scale-x-0 after:transition-transform after:duration-200 group-hover:after:scale-[1.2] aria-[current=page]:text-[#A70909] aria-expanded:text-[#A70909] aria-[current=page]:after:scale-[1.2] aria-expanded:after:scale-[1.2]";
+  const classes = active ? `${baseClasses} text-[#A70909]` : baseClasses;
 
   return (
     <Link
@@ -59,7 +59,7 @@ export default function NavLink({
         {flame ? (
           <FontAwesomeIcon
             icon={faFire}
-            className="h-4 w-4 text-[var(--brand-red)] group-hover:animate-[bounce_1.5s_infinite]"
+            className="h-4 w-4 text-[#A70909] group-hover:animate-[bounce_1.5s_infinite]"
           />
         ) : null}
         <span>{label}</span>

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -157,14 +157,14 @@ export default function Navbar({ data }: NavbarProps) {
   };
 
   return (
-    <header className="sticky top-0 z-50 bg-[var(--surface)] shadow-sm">
+    <header className="sticky top-0 z-50 bg-white shadow-sm">
       <SocialFloating />
       <div className="relative mx-auto max-w-[1280px] px-4">
-        <div className="flex h-[var(--header-h)] items-center justify-between">
+        <div className="flex h-[72px] items-center justify-between">
           <Link href={`/${locale}`} className="flex items-center gap-3" prefetch>
             <Image src="/logo.png" alt="ViRINTIRA" width={44} height={44} priority />
-            <span className="text-[22px] font-extrabold tracking-[0.02em] text-[var(--nav-text)]">
-              <span className="text-[var(--nav-text)]">Vi</span>RINTIRA
+            <span className="text-[22px] font-extrabold tracking-[0.02em] text-[#2A2A2A]">
+              <span className="text-[#2A2A2A]">Vi</span>RINTIRA
             </span>
           </Link>
 

--- a/src/components/navbar/SearchToggle.tsx
+++ b/src/components/navbar/SearchToggle.tsx
@@ -125,7 +125,7 @@ export default function SearchToggle({
         aria-expanded={open}
         aria-controls="navbar-search-panel"
         onClick={handleToggle}
-        className="rounded-full p-2 text-[var(--nav-text)] transition-colors duration-150 hover:bg-gray-100"
+        className="rounded-full p-2 text-[#2A2A2A] transition-colors duration-150 hover:bg-gray-100"
       >
         <FontAwesomeIcon icon={faSearch} className="h-5 w-5" />
       </button>
@@ -138,7 +138,7 @@ export default function SearchToggle({
       >
         <div
           ref={shellRef}
-          className="w-[min(920px,92vw)] rounded-full bg-[var(--surface)] px-4 py-2 shadow-[var(--shadow-lg)]"
+          className="w-[min(920px,92vw)] rounded-full bg-white px-4 py-2 shadow-[0_10px_25px_rgba(0,0,0,0.08)]"
         >
           <form
             action={action}
@@ -146,7 +146,7 @@ export default function SearchToggle({
             className="flex items-center gap-3"
             onSubmit={handleSubmit}
           >
-            <FontAwesomeIcon icon={faSearch} className="h-5 w-5 text-[var(--nav-muted)]" />
+            <FontAwesomeIcon icon={faSearch} className="h-5 w-5 text-[#6B7280]" />
             <input
               ref={inputRef}
               value={query}
@@ -154,11 +154,11 @@ export default function SearchToggle({
               name="q"
               autoComplete="off"
               placeholder={placeholder}
-              className="h-10 w-full bg-transparent text-[17px] leading-none text-[var(--nav-text)] outline-none placeholder:text-[var(--nav-muted)]"
+              className="h-10 w-full bg-transparent text-[17px] leading-none text-[#2A2A2A] outline-none placeholder:text-[#6B7280]"
             />
             <button
               type="submit"
-              className="rounded-full bg-[var(--brand-red)] px-5 py-1.5 text-sm font-semibold text-white transition-opacity duration-150 hover:brightness-110"
+              className="rounded-full bg-[#A70909] px-5 py-1.5 text-sm font-semibold text-white transition-opacity duration-150 hover:brightness-110"
             >
               {submitLabel}
             </button>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,12 +3,6 @@
 @tailwind utilities;
 
 :root {
-  --header-h: 72px;
-  --brand-red: #a70909;
-  --nav-text: #2a2a2a;
-  --nav-muted: #6b7280;
-  --surface: #ffffff;
-  --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.08);
   --font-size-body: clamp(0.95rem, 0.88rem + 0.35vw, 1.1rem);
   --font-size-small: clamp(0.85rem, 0.8rem + 0.25vw, 0.95rem);
   --font-size-h1: clamp(2.25rem, 1.5rem + 2.4vw, 3.5rem);


### PR DESCRIPTION
## Summary
- replace navbar CSS variable usage with explicit Tailwind-compatible colour and spacing classes
- remove obsolete navbar CSS custom properties from globals to prevent unused variables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e00dd54740832bb2d085d76373d1ff