### PR TITLE
Adjust search dropdown positioning

### DIFF
--- a/src/components/navbar/SearchToggle.tsx
+++ b/src/components/navbar/SearchToggle.tsx
@@ -132,7 +132,7 @@ export default function SearchToggle({
 
       <div
         id="navbar-search-panel"
-        className="pointer-events-none absolute left-1/2 top-full z-40 flex w-full -translate-x-1/2 justify-center pt-4 opacity-0 transition-opacity duration-150 ease-out data-[open=true]:pointer-events-auto data-[open=true]:opacity-100"
+        className="pointer-events-none fixed left-1/2 top-[calc(var(--header-height)+0px)] z-40 flex w-full -translate-x-1/2 justify-center opacity-0 transition-opacity duration-150 ease-out data-[open=true]:pointer-events-auto data-[open=true]:opacity-100"
         data-open={open ? 'true' : 'false'}
         aria-hidden={open ? undefined : 'true'}
       >


### PR DESCRIPTION
## Summary
- position the search dropdown using a fixed overlay aligned to the header height
- remove extra padding so the input overlaps the navbar without shifting layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0ce625674832bb21d130e15bd3640